### PR TITLE
feat: allow brackets when parsing library names

### DIFF
--- a/scripts/update_setup_py.sh
+++ b/scripts/update_setup_py.sh
@@ -43,7 +43,7 @@ echo -e "rules:
         constraint_files = set()
 
         # groups \"my-package-name<=x.y.z,...\" into (\"my-package-name\", \"<=x.y.z,...\")
-        requirement_line_regex = re.compile(r\"([a-zA-Z0-9-_.]+)([<>=][^#\s]+)?\")
+        requirement_line_regex = re.compile(r\"([a-zA-Z0-9-_.\[\]]+)([<>=][^#\s]+)?\")
 
         def add_version_constraint_or_raise(current_line, current_requirements, add_if_not_present):
             regex_match = requirement_line_regex.match(current_line)


### PR DESCRIPTION
**Description:**

Updates the regex used to match library names to allow brackets for things like `pyjwt[crypto]`

**JIRA:**

[ARCHBOM-1772](https://openedx.atlassian.net/browse/ARCHBOM-1772)

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed