### PR TITLE
fix: interpolate repo_name in django app makefile

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,14 @@ Change Log
    This file loosely adheres to the structure of https://keepachangelog.com/,
    but in reStructuredText instead of Markdown.
 
+2022-01-14
+----------
+
+Changed
+~~~~~~~
+
+* Makefile created for django-ida now interpolates repo_name into dockerhub commands.
+
 2021-10-27
 ----------
 

--- a/cookiecutter-django-ida/{{cookiecutter.repo_name}}/Makefile
+++ b/cookiecutter-django-ida/{{cookiecutter.repo_name}}/Makefile
@@ -190,21 +190,21 @@ db-shell: # Run the app shell as root, enter the app's database
 	docker attach {{cookiecutter.project_name}}.$*
 
 github_docker_build:
-	docker build . -f Dockerfile --target app -t openedx/repo_name
-	docker build . -f Dockerfile --target newrelic -t openedx/repo_name:latest-newrelic
+	docker build . -f Dockerfile --target app -t openedx/{{cookiecutter.repo_name}}
+	docker build . -f Dockerfile --target newrelic -t openedx/{{cookiecutter.repo_name}}:latest-newrelic
 
 github_docker_tag: github_docker_build
-	docker tag openedx/repo_name openedx/repo_name:${GITHUB_SHA}
-	docker tag openedx/repo_name:latest-newrelic openedx/repo_name:${GITHUB_SHA}-newrelic
+	docker tag openedx/{{cookiecutter.repo_name}} openedx/{{cookiecutter.repo_name}}:${GITHUB_SHA}
+	docker tag openedx/{{cookiecutter.repo_name}}:latest-newrelic openedx/{{cookiecutter.repo_name}}:${GITHUB_SHA}-newrelic
 
 github_docker_auth:
 	echo "$$DOCKERHUB_PASSWORD" | docker login -u "$$DOCKERHUB_USERNAME" --password-stdin
 
 github_docker_push: github_docker_tag github_docker_auth ## push to docker hub
-	docker push 'openedx/repo_name:latest'
-	docker push "openedx/repo_name:${GITHUB_SHA}"
-	docker push 'openedx/repo_name:latest-newrelic'
-	docker push "openedx/repo_name:${GITHUB_SHA}-newrelic"
+	docker push 'openedx/{{cookiecutter.repo_name}}:latest'
+	docker push "openedx/{{cookiecutter.repo_name}}:${GITHUB_SHA}"
+	docker push 'openedx/{{cookiecutter.repo_name}}:latest-newrelic'
+	docker push "openedx/{{cookiecutter.repo_name}}:${GITHUB_SHA}-newrelic"
 
 selfcheck: ## check that the Makefile is well-formed
 	@echo "The Makefile is well-formed."


### PR DESCRIPTION
**Description:**

This isn't related specifically to any ticket, but when I've used the cookiecutter, I ended up pushing a Docker image to openedx/repo_name because repo_name was not replaced with the actual repo_name on creation (as it is in many other places). This fixes that.

**JIRA:**

[XXX-XXXX](https://openedx.atlassian.net/browse/XXX-XXXX)

**Merge checklist:**
- [x] All reviewers approved
- [x] CI build is green
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Commits are squashed
