### PR TITLE
Use yaml.safe_load() instead of yaml.load() in IDA cookiecutter.

### DIFF
--- a/cookiecutter-django-ida/{{cookiecutter.repo_name}}/{{cookiecutter.project_name}}/settings/production.py
+++ b/cookiecutter-django-ida/{{cookiecutter.repo_name}}/{{cookiecutter.project_name}}/settings/production.py
@@ -24,7 +24,7 @@ FILE_STORAGE_BACKEND = {}
 if '{{cookiecutter.project_name|upper}}_CFG' in environ:
     CONFIG_FILE = get_env_setting('{{cookiecutter.project_name|upper}}_CFG')
     with open(CONFIG_FILE, encoding='utf-8') as f:
-        config_from_yaml = yaml.load(f)
+        config_from_yaml = yaml.safe_load(f)
 
         # Remove the items that should be used to update dicts, and apply them separately rather
         # than pumping them into the local vars.


### PR DESCRIPTION
**Description:**

fix: Use yaml.safe_load() instead of yaml.load(), which errors in `pyyaml>=6`.

Reference PRs:
https://github.com/openedx/blockstore/pull/146
https://github.com/openedx/blockstore/pull/152

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed
