### PR TITLE
feat: replace depreaction use url to re_path also include

### DIFF
--- a/cookiecutter-django-app/{{cookiecutter.repo_name}}/{{cookiecutter.app_name}}/urls.py
+++ b/cookiecutter-django-app/{{cookiecutter.repo_name}}/{{cookiecutter.app_name}}/urls.py
@@ -1,10 +1,10 @@
 """
 URLs for {{ cookiecutter.app_name }}.
 """
-from django.conf.urls import url  # pylint: disable=unused-import
+from django.urls import re_path  # pylint: disable=unused-import
 from django.views.generic import TemplateView  # pylint: disable=unused-import
 
 urlpatterns = [
     # TODO: Fill in URL patterns and views here.
-    # url(r'', TemplateView.as_view(template_name="{{ cookiecutter.app_name }}/base.html")),
+    # re_path(r'', TemplateView.as_view(template_name="{{ cookiecutter.app_name }}/base.html")),
 ]

--- a/cookiecutter-django-ida/{{cookiecutter.repo_name}}/{{cookiecutter.project_name}}/apps/api/urls.py
+++ b/cookiecutter-django-ida/{{cookiecutter.repo_name}}/{{cookiecutter.project_name}}/apps/api/urls.py
@@ -4,11 +4,11 @@ Root API URLs.
 All API URLs should be versioned, so urlpatterns should only
 contain namespaces for the active versions of the API.
 """
-from django.conf.urls import include, url
+from django.urls import include, re_path
 
 from {{cookiecutter.project_name}}.apps.api.v1 import urls as v1_urls
 
 app_name = 'api'
 urlpatterns = [
-    url(r'^v1/', include(v1_urls)),
+    re_path(r'^v1/', include(v1_urls)),
 ]

--- a/cookiecutter-django-ida/{{cookiecutter.repo_name}}/{{cookiecutter.project_name}}/urls.py
+++ b/cookiecutter-django-ida/{{cookiecutter.repo_name}}/{{cookiecutter.project_name}}/urls.py
@@ -19,8 +19,8 @@ import os
 
 from auth_backends.urls import oauth2_urlpatterns
 from django.conf import settings
-from django.conf.urls import include, url
 from django.contrib import admin
+from django.urls import include, re_path
 from rest_framework_swagger.views import get_swagger_view
 
 from {{cookiecutter.project_name}}.apps.api import urls as api_urls
@@ -29,16 +29,16 @@ from {{cookiecutter.project_name}}.apps.core import views as core_views
 admin.autodiscover()
 
 urlpatterns = oauth2_urlpatterns + [
-    url(r'^admin/', admin.site.urls),
-    url(r'^api/', include(api_urls)),
-    url(r'^api-docs/', get_swagger_view(title='{{cookiecutter.repo_name}} API')),
-    url(r'^auto_auth/$', core_views.AutoAuth.as_view(), name='auto_auth'),
-    url(r'', include('csrf.urls')),  # Include csrf urls from edx-drf-extensions
-    url(r'^health/$', core_views.health, name='health'),
+    re_path(r'^admin/', admin.site.urls),
+    re_path(r'^api/', include(api_urls)),
+    re_path(r'^api-docs/', get_swagger_view(title='{{cookiecutter.repo_name}} API')),
+    re_path(r'^auto_auth/$', core_views.AutoAuth.as_view(), name='auto_auth'),
+    re_path(r'', include('csrf.urls')),  # Include csrf urls from edx-drf-extensions
+    re_path(r'^health/$', core_views.health, name='health'),
 ]
 
 if settings.DEBUG and os.environ.get('ENABLE_DJANGO_TOOLBAR', False):  # pragma: no cover
     # Disable pylint import error because we don't install django-debug-toolbar
     # for CI build
     import debug_toolbar  # pylint: disable=import-error
-    urlpatterns.append(url(r'^__debug__/', include(debug_toolbar.urls)))
+    urlpatterns.append(re_path(r'^__debug__/', include(debug_toolbar.urls)))

--- a/tests/test_cookiecutter_django_app.py
+++ b/tests/test_cookiecutter_django_app.py
@@ -110,7 +110,7 @@ def test_models(options_baked):
 def test_urls(options_baked):
     """The urls.py file should be present."""
     urls_file_txt = Path("cookie_lover/urls.py").read_text()
-    basic_url = "url(r'', TemplateView.as_view(template_name=\"cookie_lover/base.html\"))"
+    basic_url = "re_path(r'', TemplateView.as_view(template_name=\"cookie_lover/base.html\"))"
     assert basic_url in urls_file_txt
 
 


### PR DESCRIPTION
django has depcreated the use of include and url from
django.conf.urls and instead to use re_path and include from
django.urls

**Description:**

Describe in a couple of sentences what this PR adds

**JIRA:**

[XXX-XXXX](https://openedx.atlassian.net/browse/XXX-XXXX)

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed
