### PR TITLE
feat: Add more monitoring middlewares to IDA

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,11 +5,24 @@ Change Log
    This file loosely adheres to the structure of https://keepachangelog.com/,
    but in reStructuredText instead of Markdown.
 
+2022-05-31
+----------
+
+Fixed
+~~~~~
+
+- Used newer, non-deprecated name for metrics monitoring middleware from edx-django-utils
+
+Added
+~~~~~
+
+- Added several more monitoring middlewares for IDAs
+
 2022-04-08
 ----------
 
 Fixed
-~~~~~~~~
+~~~~~
 * Fixed an issue with default config for JWT auth for new IDAs.
 
 
@@ -17,7 +30,7 @@ Fixed
 ----------
 
 Removed
-~~~~~~~~
+~~~~~~~
 * Removed redundant New Relic agent injection in Dockerfile
 
 
@@ -25,12 +38,12 @@ Removed
 ----------
 
 Added
-~~~~~~~
+~~~~~
 
 * Added Support for Django40
 
 Removed
-~~~~~~~~
+~~~~~~~
 * Removed Support for Django22, 30, 31
 
 2022-01-14

--- a/cookiecutter-django-ida/{{cookiecutter.repo_name}}/{{cookiecutter.project_name}}/settings/base.py
+++ b/cookiecutter-django-ida/{{cookiecutter.repo_name}}/{{cookiecutter.project_name}}/settings/base.py
@@ -53,8 +53,13 @@ INSTALLED_APPS += PROJECT_APPS
 MIDDLEWARE = (
     # Resets RequestCache utility for added safety.
     'edx_django_utils.cache.middleware.RequestCacheMiddleware',
-    # Enables monitoring utility for writing custom metrics.
-    'edx_django_utils.monitoring.middleware.MonitoringCustomMetricsMiddleware',
+
+    # Monitoring middleware should be immediately after RequestCacheMiddleware
+    'edx_django_utils.monitoring.DeploymentMonitoringMiddleware',  # python and django version
+    'edx_django_utils.monitoring.CookieMonitoringMiddleware',  # cookie names (compliance) and sizes
+    'edx_django_utils.monitoring.CachedCustomMonitoringMiddleware',  # support accumulate & increment
+    'edx_django_utils.monitoring.MonitoringMemoryMiddleware',  # memory usage
+
     'corsheaders.middleware.CorsMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.locale.LocaleMiddleware',


### PR DESCRIPTION
Use newer name for metrics middleware, and add cookie[1], memory usage,
and deployment middleware. Skip the code owner one that edx-django-utils
offers since most IDAs will be single-owner.

[1] https://2u-internal.atlassian.net/browse/ARCHBOM-2072
"Add CookieMonitoringMiddleware to other IDAs"

**Merge checklist:**
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Commits are squashed
