### PR TITLE
fix: squash context_processors.request, DEFAULT_AUTO_FIELD, & isort -rc warnings

### DIFF
--- a/cookiecutter-django-app/{{cookiecutter.repo_name}}/docs/conf.py
+++ b/cookiecutter-django-app/{{cookiecutter.repo_name}}/docs/conf.py
@@ -109,7 +109,7 @@ release = VERSION
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = 'en'
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:

--- a/cookiecutter-django-ida/{{cookiecutter.repo_name}}/Makefile
+++ b/cookiecutter-django-ida/{{cookiecutter.repo_name}}/Makefile
@@ -1,11 +1,11 @@
 .DEFAULT_GOAL := help
 
 .PHONY: help clean piptools requirements ci_requirements dev_requirements \
-        validation_requirements doc_requirementsprod_requirements static shell \
+        validation_requirements doc_requirements prod_requirements static shell \
         test coverage isort_check isort style lint quality pii_check validate \
         migrate html_coverage upgrade extract_translation dummy_translations \
-        compile_translations fake_translations  pull_translations \
-        push_translations start-devstack open-devstack  pkg-devstack \
+        compile_translations fake_translations pull_translations \
+        push_translations start-devstack open-devstack pkg-devstack \
         detect_changed_source_translations validate_translations check_keywords
 
 define BROWSER_PYSCRIPT

--- a/cookiecutter-django-ida/{{cookiecutter.repo_name}}/Makefile
+++ b/cookiecutter-django-ida/{{cookiecutter.repo_name}}/Makefile
@@ -68,7 +68,7 @@ coverage: clean
 	$(BROWSER) htmlcov/index.html
 
 isort_check: ## check that isort has been run
-	isort --check-only -rc {{cookiecutter.project_name}}/
+	isort --check-only {{cookiecutter.project_name}}/
 
 isort: ## run isort to sort imports in all Python files
 	isort --recursive --atomic {{cookiecutter.project_name}}/

--- a/cookiecutter-django-ida/{{cookiecutter.repo_name}}/{{cookiecutter.project_name}}/settings/base.py
+++ b/cookiecutter-django-ida/{{cookiecutter.repo_name}}/{{cookiecutter.project_name}}/settings/base.py
@@ -105,6 +105,9 @@ DATABASES = {
     }
 }
 
+# New DB primary keys default to an IntegerField.
+DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'
+
 # Internationalization
 # https://docs.djangoproject.com/en/dev/topics/i18n/
 

--- a/cookiecutter-django-ida/{{cookiecutter.repo_name}}/{{cookiecutter.project_name}}/settings/base.py
+++ b/cookiecutter-django-ida/{{cookiecutter.repo_name}}/{{cookiecutter.project_name}}/settings/base.py
@@ -148,7 +148,7 @@ STATICFILES_DIRS = (
 )
 
 # TEMPLATE CONFIGURATION
-# See: https://docs.djangoproject.com/en/2.2/ref/settings/#templates
+# See: https://docs.djangoproject.com/en/3.2/ref/settings/#templates
 TEMPLATES = [
     {
         'BACKEND': 'django.template.backends.django.DjangoTemplates',
@@ -162,6 +162,7 @@ TEMPLATES = [
                 'django.template.context_processors.debug',
                 'django.template.context_processors.i18n',
                 'django.template.context_processors.media',
+                'django.template.context_processors.request',
                 'django.template.context_processors.static',
                 'django.template.context_processors.tz',
                 'django.contrib.messages.context_processors.messages',

--- a/python-template/{{cookiecutter.placeholder_repo_name}}/docs/conf.py
+++ b/python-template/{{cookiecutter.placeholder_repo_name}}/docs/conf.py
@@ -119,7 +119,7 @@ release = VERSION
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = 'en'
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:


### PR DESCRIPTION
## Description

This PR squashes the following warnings:

* On DjangoTemplates `context_processors.request`:

      ?: (admin.W411) 'django.template.context_processors.request' must be enabled in DjangoTemplates (TEMPLATES) in order to use the admin navigation sidebar.

* On `DEFAULT_AUTO_FIELD`:

      core.User: (models.W042) Auto-created primary key used when not defining a primary key type, by default 'django.db.models.AutoField'.
          HINT: Configure the DEFAULT_AUTO_FIELD setting or the CoreConfig.default_auto_field attribute to point to a subclass of AutoField, e.g. 'django.db.models.BigAutoField'.

* On isort (when running `make validate`):

      lib/python3.8/site-packages/isort/main.py:<line>: UserWarning: W0501: The following deprecated CLI flags were used and ignored: -rc!

* On Sphinx `language`:

      Invalid configuration value found: 'language = None'. Update your configuration to a valid langauge code. Falling back to 'en' (English).

See individual commit messages for more research.

## Additional information

* Acknowledgements: @alangsto, for providing how to fix the warnings at https://github.com/edx/edx-exams/pull/9. Thank you!
* See also: https://github.com/edx/commerce-coordinator/pull/30

## Checklist
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed
