### PR TITLE
fix: Various (correct variable; tags; placement and punctuation; versions

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,18 @@ Change Log
    This file loosely adheres to the structure of https://keepachangelog.com/,
    but in reStructuredText instead of Markdown.
 
+2022-07-11
+----------
+
+Fixed
+~~~~~
+
+- Fix or remove ``tags`` repo metadata in several templates
+- Remove extraneous period after short description
+- Move short description to top of readme
+- Use project name, not repo name, for package name in setup.py
+- Change Django documentation and setup.py references from 2.2 to 3.2
+
 2022-07-05
 ----------
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,7 +11,7 @@ Change Log
 Fixed
 ~~~~~
 
-- Fix or remove ``tags`` repo metadata in several templates
+- Fix or remove ``tags`` repo metadata in several templates; remove deprecated ``nick`` from openedx.yaml (see OEP-2)
 - Remove extraneous period after short description
 - Move short description to top of readme
 - Use project name, not repo name, for package name in setup.py

--- a/cookiecutter-django-app/cookiecutter.json
+++ b/cookiecutter-django-app/cookiecutter.json
@@ -3,7 +3,7 @@
   "app_name": "{{ cookiecutter.repo_name.lower()|replace(' ', '_')|replace('-', '_')|replace('.', '_') }}",
   "project_name": "{{ cookiecutter.repo_name }}",
   "project_title": "{{ cookiecutter.project_name }}",
-  "project_short_description": "What is this project?",
+  "project_short_description": "One-line description for README and other doc files.",
   "version": "0.1.0",
   "author_name": "edX",
   "author_email": "you@edx.org",

--- a/cookiecutter-django-app/{{cookiecutter.repo_name}}/docs/conf.py
+++ b/cookiecutter-django-app/{{cookiecutter.repo_name}}/docs/conf.py
@@ -470,7 +470,7 @@ epub_exclude_files = ['search.html']
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
     'python': ('https://docs.python.org/3.8', None),
-    'django': ('https://docs.djangoproject.com/en/2.2/', 'https://docs.djangoproject.com/en/2.2/_objects/'),
+    'django': ('https://docs.djangoproject.com/en/3.2/', 'https://docs.djangoproject.com/en/3.2/_objects/'),
     'model_utils': ('https://django-model-utils.readthedocs.io/en/latest/', None),
 }
 

--- a/cookiecutter-django-app/{{cookiecutter.repo_name}}/{{cookiecutter.app_name}}/__init__.py
+++ b/cookiecutter-django-app/{{cookiecutter.repo_name}}/{{cookiecutter.app_name}}/__init__.py
@@ -1,5 +1,5 @@
 """
-{{ cookiecutter.project_short_description }}.
+{{ cookiecutter.project_short_description }}
 """
 
 __version__ = '{{ cookiecutter.version }}'

--- a/cookiecutter-django-ida/README.rst
+++ b/cookiecutter-django-ida/README.rst
@@ -9,7 +9,7 @@ A cookiecutter_ template for edX Django projects.
 
 This cookiecutter template is intended for new edX independently deployable apps (IDAs). It includes the following packages:
 
-* Django 2.2
+* Django 3.2
 * Django REST Framework
 * Django Waffle
 

--- a/cookiecutter-django-ida/cookiecutter.json
+++ b/cookiecutter-django-ida/cookiecutter.json
@@ -1,7 +1,7 @@
 {
   "repo_name": "repo_name",
   "project_name": "{{ cookiecutter.repo_name.lower()|replace(' ', '_')|replace('-', '_')|replace('.', '_')|trim() }}",
-  "project_short_description": "What is this project?",
+  "project_short_description": "One-line description for README and other doc files.",
   "version": "0.1.0",
   "author_name": "edX",
   "author_email": "you@edx.org",

--- a/cookiecutter-django-ida/{{cookiecutter.repo_name}}/{{cookiecutter.project_name}}/settings/base.py
+++ b/cookiecutter-django-ida/{{cookiecutter.repo_name}}/{{cookiecutter.project_name}}/settings/base.py
@@ -92,7 +92,7 @@ ROOT_URLCONF = '{{cookiecutter.project_name}}.urls'
 WSGI_APPLICATION = '{{cookiecutter.project_name}}.wsgi.application'
 
 # Database
-# https://docs.djangoproject.com/en/2.2/ref/settings/#databases
+# https://docs.djangoproject.com/en/3.2/ref/settings/#databases
 # Set this value in the environment-specific files (e.g. local.py, production.py, test.py)
 DATABASES = {
     'default': {

--- a/cookiecutter-django-ida/{{cookiecutter.repo_name}}/{{cookiecutter.project_name}}/urls.py
+++ b/cookiecutter-django-ida/{{cookiecutter.repo_name}}/{{cookiecutter.project_name}}/urls.py
@@ -2,7 +2,7 @@
 {{ cookiecutter.project_name }} URL Configuration.
 
 The `urlpatterns` list routes URLs to views. For more information please see:
-    https://docs.djangoproject.com/en/2.2/topics/http/urls/
+    https://docs.djangoproject.com/en/3.2/topics/http/urls/
 Examples:
 Function views
     1. Add an import:  from my_app import views

--- a/cookiecutter-django-ida/{{cookiecutter.repo_name}}/{{cookiecutter.project_name}}/wsgi.py
+++ b/cookiecutter-django-ida/{{cookiecutter.repo_name}}/{{cookiecutter.project_name}}/wsgi.py
@@ -4,7 +4,7 @@ WSGI config for {{cookiecutter.repo_name}}.
 It exposes the WSGI callable as a module-level variable named ``application``.
 
 For more information on this file, see
-https://docs.djangoproject.com/en/2.2/howto/deployment/wsgi/
+https://docs.djangoproject.com/en/3.2/howto/deployment/wsgi/
 """
 import os
 from os.path import abspath, dirname

--- a/cookiecutter-python-library/cookiecutter.json
+++ b/cookiecutter-python-library/cookiecutter.json
@@ -2,7 +2,7 @@
   "repo_name": "repo_name",
   "library_name": "{{ cookiecutter.repo_name.lower()|replace(' ', '_')|replace('-', '_')|replace('.', '_') }}",
   "project_name": "{{ cookiecutter.repo_name }}",
-  "project_short_description": "What is this project?",
+  "project_short_description": "One-line description for README and other doc files.",
   "version": "0.1.0",
   "author_name": "edX",
   "author_email": "you@edx.org",

--- a/cookiecutter-xblock/openedx.yaml
+++ b/cookiecutter-xblock/openedx.yaml
@@ -5,4 +5,4 @@ oeps:
     oep-2: true
     oep-7: false
 tags:
-    - backend-tooling
+    - xblock

--- a/cookiecutter-xblock/{{cookiecutter.repo_name}}/README.rst
+++ b/cookiecutter-xblock/{{cookiecutter.repo_name}}/README.rst
@@ -71,7 +71,7 @@ These catalogs can be created by running::
 The previous command will create the necessary ``.po`` files under
 ``{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/locale/en/LC_MESSAGES/text.po``.
 The ``text.po`` file is created from the ``django-partial.po`` file created by
-``django-admin makemessages`` (`makemessages documentation <https://docs.djangoproject.com/en/2.2/topics/i18n/translation/#message-files>`_),
+``django-admin makemessages`` (`makemessages documentation <https://docs.djangoproject.com/en/3.2/topics/i18n/translation/#message-files>`_),
 this is why you will not see a ``django-partial.po`` file.
 
 3. Create language specific translations
@@ -114,7 +114,7 @@ Once translations are in place, use the following Make target to compile the tra
     $ make compile_translations
 
 The previous command will compile ``.po`` files using
-``django-admin compilemessages`` (`compilemessages documentation <https://docs.djangoproject.com/en/2.2/topics/i18n/translation/#compiling-message-files>`_).
+``django-admin compilemessages`` (`compilemessages documentation <https://docs.djangoproject.com/en/3.2/topics/i18n/translation/#compiling-message-files>`_).
 After compiling the ``.po`` file(s), ``django-statici18n`` is used to create language specific catalogs. See
 ``django-statici18n`` `documentation <https://django-statici18n.readthedocs.io/en/latest/>`_ for more information.
 
@@ -147,5 +147,5 @@ If there are any errors compiling ``.po`` files run the following command to val
     $ make validate
 
 See `django's i18n troubleshooting documentation
-<https://docs.djangoproject.com/en/2.2/topics/i18n/translation/#troubleshooting-gettext-incorrectly-detects-python-format-in-strings-with-percent-signs>`_
+<https://docs.djangoproject.com/en/3.2/topics/i18n/translation/#troubleshooting-gettext-incorrectly-detects-python-format-in-strings-with-percent-signs>`_
 for more information.

--- a/cookiecutter-xblock/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/locale/settings.py
+++ b/cookiecutter-xblock/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/locale/settings.py
@@ -1,9 +1,9 @@
 """
 Django settings for {{cookiecutter.package_name}} project.
 For more information on this file, see
-https://docs.djangoproject.com/en/2.2/topics/settings/
+https://docs.djangoproject.com/en/3.2/topics/settings/
 For the full list of settings and their values, see
-https://docs.djangoproject.com/en/2.2/ref/settings/
+https://docs.djangoproject.com/en/3.2/ref/settings/
 """
 import os
 
@@ -17,7 +17,7 @@ INSTALLED_APPS = (
 )
 
 # Internationalization
-# https://docs.djangoproject.com/en/2.2/topics/i18n/
+# https://docs.djangoproject.com/en/3.2/topics/i18n/
 
 LANGUAGE_CODE = 'en-us'
 
@@ -31,7 +31,7 @@ USE_TZ = True
 
 
 # Static files (CSS, JavaScript, Images)
-# https://docs.djangoproject.com/en/2.2/howto/static-files/
+# https://docs.djangoproject.com/en/3.2/howto/static-files/
 
 STATIC_URL = '/static/'
 

--- a/openedx.yaml
+++ b/openedx.yaml
@@ -1,4 +1,3 @@
-nick: edx-cookiecutters
 tags:
     - tools
 oeps:

--- a/python-template/cookiecutter.json
+++ b/python-template/cookiecutter.json
@@ -2,7 +2,7 @@
   "repo_name": "repo_name",
   "sub_dir_name": "{{ cookiecutter.repo_name }}",
   "project_name": "{{ cookiecutter.repo_name }}",
-  "project_short_description": "What is this project?",
+  "project_short_description": "One-line description for README and other doc files.",
   "version": "0.1.0",
   "author_name": "edX",
   "author_email": "you@edx.org",

--- a/python-template/{{cookiecutter.placeholder_repo_name}}/README.rst
+++ b/python-template/{{cookiecutter.placeholder_repo_name}}/README.rst
@@ -4,12 +4,12 @@
 |pypi-badge| |ci-badge| |codecov-badge| |doc-badge| |pyversions-badge|
 |license-badge|
 
+{{ cookiecutter.project_short_description}}
+
 The ``README.rst`` file should start with a brief description of the repository,
 which sets it in the context of other repositories under the ``edx``
 organization. It should make clear where this fits in to the overall edX
 codebase.
-
-{{ cookiecutter.project_short_description}}
 
 Overview (please modify)
 ------------------------

--- a/python-template/{{cookiecutter.placeholder_repo_name}}/openedx.yaml
+++ b/python-template/{{cookiecutter.placeholder_repo_name}}/openedx.yaml
@@ -2,7 +2,6 @@
 # https://open-edx-proposals.readthedocs.io/en/latest/oep-0002-bp-repo-metadata.html#specification
 
 ---
-nick: {{ cookiecutter.repo_name }}
 oeps:
     oep-2: true
     oep-3:

--- a/python-template/{{cookiecutter.placeholder_repo_name}}/openedx.yaml
+++ b/python-template/{{cookiecutter.placeholder_repo_name}}/openedx.yaml
@@ -3,8 +3,6 @@
 
 ---
 nick: {{ cookiecutter.repo_name }}
-tags:
-    - tools
 oeps:
     oep-2: true
     oep-3:

--- a/python-template/{{cookiecutter.placeholder_repo_name}}/setup.py
+++ b/python-template/{{cookiecutter.placeholder_repo_name}}/setup.py
@@ -119,7 +119,7 @@ README = open(os.path.join(os.path.dirname(__file__), 'README.rst'), encoding="u
 CHANGELOG = open(os.path.join(os.path.dirname(__file__), 'CHANGELOG.rst'), encoding="utf8").read()
 
 setup(
-    name='{{ cookiecutter.repo_name }}',
+    name='{{ cookiecutter.project_name }}',
     version=VERSION,
     description="""{{ cookiecutter.project_short_description }}""",
     long_description=README + '\n\n' + CHANGELOG,
@@ -141,7 +141,7 @@ setup(
         'Development Status :: 3 - Alpha',
         {%- if cookiecutter.requires_django == "yes" %}
         'Framework :: Django',
-        'Framework :: Django :: 2.2',
+        'Framework :: Django :: 3.2',
         {%- endif %}
         'Intended Audience :: Developers',
         {%- if cookiecutter.open_source_license == "AGPL 3.0" %}


### PR DESCRIPTION
- Fix or remove `tags` repo metadata in several templates
- Remove extraneous period after short description (required changing the
  default/prompt to end with a period so that linter wouldn't complain in
  test runs.)
- Move short description to top of readme
- Use project name, not repo name, for package name in setup.py
- Change Django documentation and setup.py references from 2.2 to 3.2

**Merge checklist:**
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Commits are squashed
