### PR TITLE
fix: update RequestMetricsMiddleware to RequestCustomAttributesMiddleware

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,14 @@ Change Log
    This file loosely adheres to the structure of https://keepachangelog.com/,
    but in reStructuredText instead of Markdown.
 
+2022-06-30
+----------
+
+Fixed
+~~~~~
+
+- Used newer, non-deprecated name for middleware to add custom attributes to requests from edx-drf-extensions
+
 2022-05-31
 ----------
 

--- a/cookiecutter-django-ida/{{cookiecutter.repo_name}}/{{cookiecutter.project_name}}/settings/base.py
+++ b/cookiecutter-django-ida/{{cookiecutter.repo_name}}/{{cookiecutter.project_name}}/settings/base.py
@@ -74,7 +74,7 @@ MIDDLEWARE = (
     # Enables force_django_cache_miss functionality for TieredCache.
     'edx_django_utils.cache.middleware.TieredCacheMiddleware',
     # Outputs monitoring metrics for a request.
-    'edx_rest_framework_extensions.middleware.RequestMetricsMiddleware',
+    'edx_rest_framework_extensions.middleware.RequestCustomAttributesMiddleware',
     # Ensures proper DRF permissions in support of JWTs
     'edx_rest_framework_extensions.auth.jwt.middleware.EnsureJWTAuthSettingsMiddleware',
 )


### PR DESCRIPTION
## Description

RequestMetricsMiddleware has been renamed to RequestCustomAttributesMiddleware.

This PR squashes this warning:

    .virtualenvs/cc/lib/python3.8/site-packages/edx_rest_framework_extensions/middleware.py:198: DeprecationWarning: Use 'RequestCustomAttributesMiddleware' in place of 'RequestMetricsMiddleware'.

## Additional Information

* See: [edx-drf-extensions docs](https://edx-drf-extensions.readthedocs.io/en/7.0.1/middleware.html#edx_rest_framework_extensions.middleware.RequestMetricsMiddleware)
* Related PR: https://github.com/edx/commerce-coordinator/pull/38

## Checklist
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed
