### PR TITLE
fix: Update the slack invite link.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -169,7 +169,7 @@ Our real-time conversations are on Slack. You can request a `Slack invitation`_,
 
 For more information about these options, see the `Getting Help`_ page.
 
-.. _Slack invitation: https://openedx-slack-invite.herokuapp.com/
+.. _Slack invitation: https://openedx.org/slack
 .. _community Slack workspace: https://openedx.slack.com/
 .. _Getting Help: https://openedx.org/getting-help
 .. _tox: https://tox.readthedocs.io/en/latest/

--- a/cookiecutter-django-ida/README.rst
+++ b/cookiecutter-django-ida/README.rst
@@ -114,6 +114,6 @@ Our real-time conversations are on Slack. You can request a `Slack invitation`_,
 
 For more information about these options, see the `Getting Help`_ page.
 
-.. _Slack invitation: https://openedx-slack-invite.herokuapp.com/
+.. _Slack invitation: https://openedx.org/slack
 .. _community Slack workspace: https://openedx.slack.com/
 .. _Getting Help: https://openedx.org/getting-help

--- a/cookiecutter-python-library/README.rst
+++ b/cookiecutter-python-library/README.rst
@@ -76,6 +76,6 @@ Our real-time conversations are on Slack. You can request a `Slack invitation`_,
 
 For more information about these options, see the `Getting Help`_ page.
 
-.. _Slack invitation: https://openedx-slack-invite.herokuapp.com/
+.. _Slack invitation: https://openedx.org/slack
 .. _community Slack workspace: https://openedx.slack.com/
 .. _Getting Help: https://openedx.org/getting-help

--- a/python-template/{{cookiecutter.placeholder_repo_name}}/README.rst
+++ b/python-template/{{cookiecutter.placeholder_repo_name}}/README.rst
@@ -109,7 +109,7 @@ Our real-time conversations are on Slack. You can request a `Slack invitation`_,
 
 For more information about these options, see the `Getting Help`_ page.
 
-.. _Slack invitation: https://openedx-slack-invite.herokuapp.com/
+.. _Slack invitation: https://openedx.org/slack
 .. _community Slack workspace: https://openedx.slack.com/
 .. _Getting Help: https://openedx.org/getting-help
 


### PR DESCRIPTION
Point to the openedx.org shortcut which we can update as needed.