### PR TITLE
fix: Make django-app unit tests work; test this in cookiecutter CI

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,7 @@ Fixed
 ~~~~~
 
 - Only run ``make check_keywords`` for IDAs, not all repos
+- Ensure django-app unit tests will work, and test this in cookiecutter's own CI
 
 2022-07-11
 ----------

--- a/cookiecutter-django-app/{{cookiecutter.repo_name}}/Makefile
+++ b/cookiecutter-django-app/{{cookiecutter.repo_name}}/Makefile
@@ -56,7 +56,7 @@ pii_check: ## check for PII annotations on all Django models
 piptools: ## install pinned version of pip-compile and pip-sync
 	pip install -r requirements/pip.txt
 	pip install -r requirements/pip-tools.txt
-	
+
 requirements: piptools ## install development environment requirements
 	pip-sync -q requirements/dev.txt requirements/private.*
 
@@ -68,6 +68,7 @@ diff_cover: test ## find diff lines that need test coverage
 
 test-all: quality pii_check ## run tests on every supported Python/Django combination
 	tox
+	tox -e docs
 
 validate: quality pii_check test ## run tests and quality checks
 

--- a/cookiecutter-django-app/{{cookiecutter.repo_name}}/tests/test_models.py
+++ b/cookiecutter-django-app/{{cookiecutter.repo_name}}/tests/test_models.py
@@ -14,4 +14,13 @@ class Test{{ model }}:
     def test_something(self):
         """TODO: Write real test cases."""
 {%- endfor -%}
+{%- else %}
+
+
+def test_placeholder():
+    """
+    Placeholder to allow pytest to succeed before real tests are in place.
+
+    (If there are no tests, it will exit with code 5.)
+    """
 {%- endif %}

--- a/cookiecutter-django-app/{{cookiecutter.repo_name}}/tox.ini
+++ b/cookiecutter-django-app/{{cookiecutter.repo_name}}/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py38-django{32,40}, quality, docs, pii_check
+envlist = py38-django{32,40}
 
 [doc8]
 ; D001 = Line too long

--- a/tests/test_cookiecutter_django_app.py
+++ b/tests/test_cookiecutter_django_app.py
@@ -175,3 +175,11 @@ def test_quality(options_baked):
         sh.doc8("docs", ignore_path="docs/_build")
     except sh.ErrorReturnCode as exc:
         pytest.fail(str(exc))
+
+
+def test_tests(options_baked):
+    """Make sure the tox default tests work"""
+    try:
+        run_in_virtualenv('pip install -r requirements/ci.txt; tox')
+    except sh.ErrorReturnCode as exc:
+        pytest.fail(str(exc.stderr))


### PR DESCRIPTION
- Add placeholder test to allow pytest to run without complaining about
  not finding any tests (exit code 5).
- Trim tox default envs to just pytest ones; add `doc` env explicitly to
  `test-all` Makefile target to compensate.

This just fixes cookiecutter-django-app for now; other cookiecutters can
be fixed once this is shown to work.

**Merge checklist:**
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Commits are squashed
