### PR TITLE
Fix requirements upgrade

### DIFF
--- a/python-template/{{cookiecutter.placeholder_repo_name}}/requirements/pip-tools.txt
+++ b/python-template/{{cookiecutter.placeholder_repo_name}}/requirements/pip-tools.txt
@@ -10,7 +10,7 @@ click==8.1.3
     # via pip-tools
 packaging==21.3
     # via build
-pep517==0.12.0
+pep517==0.13.0
     # via build
 pip-tools==6.8.0
     # via -r python-template/{{cookiecutter.placeholder_repo_name}}/requirements/pip-tools.in

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -99,7 +99,7 @@ typing-extensions==4.3.0
     # via
     #   astroid
     #   pylint
-urllib3==1.26.10
+urllib3==1.26.11
     # via requests
 wrapt==1.14.1
     # via astroid

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -21,12 +21,10 @@ py==1.11.0
 pyparsing==3.0.9
     # via packaging
 six==1.16.0
-    # via
-    #   tox
-    #   virtualenv
+    # via tox
 toml==0.10.2
     # via tox
 tox==3.25.1
     # via -r requirements/ci.in
-virtualenv==20.15.1
+virtualenv==20.16.2
     # via tox

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -14,6 +14,9 @@
 # Imposed by pytest-cookies 0.5.1 to continue supporting Python 3.4
 arrow<0.14.0
 
+# doc8==1.0.0 requires docutils>=0.19 but sphinx_rtd_theme latest version requires <0.18
+doc8<1.0.0
+
 # These only make sense on Mac
 pyobjc-core; sys_platform == 'darwin'
 pyobjc-framework-cocoa; sys_platform == 'darwin'

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -22,7 +22,7 @@ astroid==2.11.7
     #   -r requirements/test.txt
     #   pylint
     #   pylint-celery
-attrs==21.4.0
+attrs==22.1.0
     # via
     #   -r requirements/test.txt
     #   pytest
@@ -47,10 +47,6 @@ certifi==2022.6.15
     # via
     #   -r requirements/test.txt
     #   requests
-cffi==1.15.1
-    # via
-    #   -r requirements/test.txt
-    #   cryptography
 chardet==5.0.0
     # via
     #   -r requirements/test.txt
@@ -84,10 +80,6 @@ cookiecutter==2.1.1
     # via
     #   -r requirements/test.txt
     #   pytest-cookies
-cryptography==37.0.4
-    # via
-    #   -r requirements/test.txt
-    #   secretstorage
 dill==0.3.5.1
     # via
     #   -r requirements/test.txt
@@ -105,7 +97,9 @@ django==3.2.14
 django-model-utils==4.2.0
     # via -r requirements/test.txt
 doc8==0.11.2
-    # via -r requirements/test.txt
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/test.txt
 docutils==0.17.1
     # via
     #   -r requirements/test.txt
@@ -146,11 +140,6 @@ isort==5.10.1
     # via
     #   -r requirements/test.txt
     #   pylint
-jeepney==0.8.0
-    # via
-    #   -r requirements/test.txt
-    #   keyring
-    #   secretstorage
 jinja2==3.1.2
     # via
     #   -r requirements/test.txt
@@ -191,7 +180,7 @@ pbr==5.9.0
     # via
     #   -r requirements/test.txt
     #   stevedore
-pep517==0.12.0
+pep517==0.13.0
     # via
     #   -r requirements/pip-tools.txt
     #   -r requirements/test.txt
@@ -220,12 +209,8 @@ py==1.11.0
     #   -r requirements/test.txt
     #   pytest
     #   tox
-pycodestyle==2.8.0
+pycodestyle==2.9.0
     # via -r requirements/test.txt
-pycparser==2.21
-    # via
-    #   -r requirements/test.txt
-    #   cffi
 pydocstyle==6.1.1
     # via -r requirements/test.txt
 pygments==2.12.0
@@ -313,10 +298,6 @@ rich==12.5.1
     # via
     #   -r requirements/test.txt
     #   twine
-secretstorage==3.3.2
-    # via
-    #   -r requirements/test.txt
-    #   keyring
 sh==1.14.3
     # via -r requirements/test.txt
 six==1.16.0
@@ -328,13 +309,12 @@ six==1.16.0
     #   edx-sphinx-theme
     #   python-dateutil
     #   tox
-    #   virtualenv
 snowballstemmer==2.2.0
     # via
     #   -r requirements/test.txt
     #   pydocstyle
     #   sphinx
-sphinx==5.1.0
+sphinx==5.1.1
     # via
     #   -r requirements/test.txt
     #   edx-sphinx-theme
@@ -408,12 +388,12 @@ typing-extensions==4.3.0
     #   astroid
     #   pylint
     #   rich
-urllib3==1.26.10
+urllib3==1.26.11
     # via
     #   -r requirements/test.txt
     #   requests
     #   twine
-virtualenv==20.15.1
+virtualenv==20.16.2
     # via
     #   -r requirements/ci.txt
     #   -r requirements/test.txt

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -10,7 +10,7 @@ click==8.1.3
     # via pip-tools
 packaging==21.3
     # via build
-pep517==0.12.0
+pep517==0.13.0
     # via build
 pip-tools==6.8.0
     # via -r requirements/pip-tools.in

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -8,7 +8,7 @@ wheel==0.37.1
     # via -r requirements/pip.in
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==22.2
+pip==22.2.1
     # via -r requirements/pip.in
 setuptools==59.8.0
     # via

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -18,7 +18,7 @@ astroid==2.11.7
     #   -r requirements/base.txt
     #   pylint
     #   pylint-celery
-attrs==21.4.0
+attrs==22.1.0
     # via pytest
 babel==2.10.3
     # via sphinx
@@ -34,8 +34,6 @@ certifi==2022.6.15
     # via
     #   -r requirements/base.txt
     #   requests
-cffi==1.15.1
-    # via cryptography
 chardet==5.0.0
     # via
     #   -r requirements/base.txt
@@ -65,8 +63,6 @@ cookiecutter==2.1.1
     # via
     #   -r requirements/base.txt
     #   pytest-cookies
-cryptography==37.0.4
-    # via secretstorage
 dill==0.3.5.1
     # via
     #   -r requirements/base.txt
@@ -81,7 +77,9 @@ django==3.2.14
 django-model-utils==4.2.0
     # via -r requirements/test.in
 doc8==0.11.2
-    # via -r requirements/test.in
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/test.in
 docutils==0.17.1
     # via
     #   doc8
@@ -115,10 +113,6 @@ isort==5.10.1
     #   -r requirements/base.txt
     #   -r requirements/test.in
     #   pylint
-jeepney==0.8.0
-    # via
-    #   keyring
-    #   secretstorage
 jinja2==3.1.2
     # via
     #   -r requirements/base.txt
@@ -153,7 +147,7 @@ pbr==5.9.0
     # via
     #   -r requirements/base.txt
     #   stevedore
-pep517==0.12.0
+pep517==0.13.0
     # via build
 pkginfo==1.8.3
     # via twine
@@ -166,10 +160,8 @@ pluggy==1.0.0
     # via pytest
 py==1.11.0
     # via pytest
-pycodestyle==2.8.0
+pycodestyle==2.9.0
     # via -r requirements/test.in
-pycparser==2.21
-    # via cffi
 pydocstyle==6.1.1
     # via -r requirements/test.in
 pygments==2.12.0
@@ -239,8 +231,6 @@ rfc3986==2.0.0
     # via twine
 rich==12.5.1
     # via twine
-secretstorage==3.3.2
-    # via keyring
 sh==1.14.3
     # via -r requirements/test.in
 six==1.16.0
@@ -250,12 +240,11 @@ six==1.16.0
     #   edx-lint
     #   edx-sphinx-theme
     #   python-dateutil
-    #   virtualenv
 snowballstemmer==2.2.0
     # via
     #   pydocstyle
     #   sphinx
-sphinx==5.1.0
+sphinx==5.1.1
     # via
     #   -r requirements/test.in
     #   edx-sphinx-theme
@@ -304,12 +293,12 @@ typing-extensions==4.3.0
     #   astroid
     #   pylint
     #   rich
-urllib3==1.26.10
+urllib3==1.26.11
     # via
     #   -r requirements/base.txt
     #   requests
     #   twine
-virtualenv==20.15.1
+virtualenv==20.16.2
     # via -r requirements/test.in
 webencodings==0.5.1
     # via bleach


### PR DESCRIPTION
`sphinx_rtd_theme` requires docutils<0.18 which causes issues with doc8==1.0.0. This PR pins doc8 to resolve the issue
https://github.com/readthedocs/sphinx_rtd_theme/blob/master/setup.py#L122