### PR TITLE
build: docker tweaks

### DIFF
--- a/cookiecutter-django-ida/{{cookiecutter.repo_name}}/Dockerfile
+++ b/cookiecutter-django-ida/{{cookiecutter.repo_name}}/Dockerfile
@@ -29,7 +29,8 @@ RUN apt-get update && apt-get -qy install --no-install-recommends \
  libmysqlclient-dev \
  libssl-dev \
  python3-dev \
- gcc
+ gcc \
+ build-essential \
 
 
 RUN pip install --upgrade pip setuptools

--- a/cookiecutter-django-ida/{{cookiecutter.repo_name}}/docker-compose.yml
+++ b/cookiecutter-django-ida/{{cookiecutter.repo_name}}/docker-compose.yml
@@ -19,10 +19,14 @@ services:
     # Uncomment this line to use the official {{cookiecutter.project_name}} base image
     image: openedx/{{cookiecutter.project_name}}
 
+    build:
+      context: .
+      dockerfile: Dockerfile
+
     container_name: {{cookiecutter.project_name}}.app
     volumes:
-      - .:/edx/app/{{cookiecutter.project_name}}/
-    command: bash -c 'while true; do python /edx/app/{{cookiecutter.project_name}}/manage.py runserver 0.0.0.0:{{cookiecutter.port}}; sleep 2; done'
+      - .:/edx/app/{{cookiecutter.placeholder_repo_name}}/
+    command: bash -c 'while true; do python /edx/app/{{cookiecutter.placeholder_repo_name}}/manage.py runserver 0.0.0.0:{{cookiecutter.port}}; sleep 2; done'
     environment:
       DJANGO_SETTINGS_MODULE: {{cookiecutter.project_name}}.settings.devstack
     ports:

--- a/cookiecutter-django-ida/{{cookiecutter.repo_name}}/provision-{{cookiecutter.repo_name}}.sh
+++ b/cookiecutter-django-ida/{{cookiecutter.repo_name}}/provision-{{cookiecutter.repo_name}}.sh
@@ -1,3 +1,4 @@
+repo_name ="{{cookiecutter.placeholder_repo_name}}"
 name="{{cookiecutter.project_name}}"
 port="{{cookiecutter.port}}"
 
@@ -20,11 +21,11 @@ docker exec -i {{cookiecutter.project_name}}.db mysql -u root -se "CREATE DATABA
 
 # Run migrations
 echo -e "${GREEN}Running migrations for ${name}...${NC}"
-docker exec -t {{cookiecutter.project_name}}.app bash -c "cd /edx/app/${name}/ && make migrate"
+docker exec -t {{cookiecutter.project_name}}.app bash -c "cd /edx/app/${repo_name}/ && make migrate"
 
 # Create superuser
 echo -e "${GREEN}Creating super-user for ${name}...${NC}"
-docker exec -t {{cookiecutter.project_name}}.app bash -c "echo 'from django.contrib.auth import get_user_model; User = get_user_model(); User.objects.create_superuser(\"edx\", \"edx@example.com\", \"edx\") if not User.objects.filter(username=\"edx\").exists() else None' | python /edx/app/${name}/manage.py shell"
+docker exec -t {{cookiecutter.project_name}}.app bash -c "echo 'from django.contrib.auth import get_user_model; User = get_user_model(); User.objects.create_superuser(\"edx\", \"edx@example.com\", \"edx\") if not User.objects.filter(username=\"edx\").exists() else None' | python /edx/app/${repo_name}/manage.py shell"
 
 # Provision IDA User in LMS
 echo -e "${GREEN}Provisioning ${name}_worker in LMS...${NC}"


### PR DESCRIPTION
**Description:**
Adding solutions to issues discovered in program-intent-engagement repo:
- https://github.com/edx/program-intent-engagement/pull/9
  - This has docker use a docker-compose.yml build directive instead of from a docker image
  - This edit is made because right now docker won't work without a published image
- https://github.com/edx/program-intent-engagement/pull/17
  - This is the provisioning tweak changes that resolved an issue with creating docker images on the right path
  - added $repo_name to the provision script so it references the correct paths
