### PR TITLE
fix: ignore rendering of workflows/ci.yml to avoid  'matrix' is undefined error

### DIFF
--- a/cookiecutter-xblock/cookiecutter.json
+++ b/cookiecutter-xblock/cookiecutter.json
@@ -7,5 +7,8 @@
   "class_name": "MyXBlock",
   "author_name": "edX",
   "author_email": "you@edx.org",
-  "open_source_license": ["AGPL 3.0", "Apache Software License 2.0", "Not open source"]
+  "open_source_license": ["AGPL 3.0", "Apache Software License 2.0", "Not open source"],
+  "_copy_without_render": [
+    ".github/workflows/*.yml"
+  ]  
 }


### PR DESCRIPTION
This PR has changes to stop rendering of `workflows/ci.yml` in case of **cookiecutter-xblock** to avoid `'matrix' is undefined error` error.