### PR TITLE
build: include packages in a safer, more-standard way

### DIFF
--- a/python-template/{{cookiecutter.placeholder_repo_name}}/MANIFEST.in
+++ b/python-template/{{cookiecutter.placeholder_repo_name}}/MANIFEST.in
@@ -3,4 +3,4 @@ include LICENSE.txt
 include README.rst
 include requirements/base.in
 include requirements/constraints.txt
-recursive-include {{cookiecutter.sub_dir_name}} *.html *.png *.gif *.js *.css *.jpg *.jpeg *.svg *.py
+recursive-include {{cookiecutter.sub_dir_name}} *.html *.png *.gif *.js *.css *.jpg *.jpeg *.svg

--- a/python-template/{{cookiecutter.placeholder_repo_name}}/setup.py
+++ b/python-template/{{cookiecutter.placeholder_repo_name}}/setup.py
@@ -6,7 +6,7 @@ import os
 import re
 import sys
 
-from setuptools import setup
+from setuptools import find_packages, setup
 
 {%- set license_classifiers = ['AGPL 3.0', 'Apache Software License 2.0'] %}
 
@@ -127,9 +127,10 @@ setup(
     author='edX',
     author_email='oscm@edx.org',
     url='https://github.com/edx/{{ cookiecutter.repo_name }}',
-    packages=[
-        '{{ cookiecutter.sub_dir_name }}',
-    ],
+    packages=find_packages(
+        include=['{{ cookiecutter.sub_dir_name }}'],
+        exclude=["*tests"],
+    ),
     include_package_data=True,
     install_requires=load_requirements('requirements/base.in'),
     python_requires=">=3.8",


### PR DESCRIPTION
**Description:**

The standard way for setup.py to include Python packages is:

    setup(..., packages=find_packages(exclude=[...]), ...)

which will ensure that every package (including sub-packages) in a Python project will be included in the built wheel, unless explicitly excluded.

Up until this point, though, we've been achieving this in a different, very strange way:

    setup(..., packages=["<root_package>"], include_package_data=True, ...)

which normally would only include the root packages (for example, `blockstore` but not `blockstore.apps`), except for the fact that we explicitly include Python packages in MANIFEST.in:

    recursive-include <root_package> ... *.jpeg *.svg *.py

**Review:**

@regisb can you take a look? and can you fact-check my commit message? Tbh, I don't fully understand the difference between `find_packages()` and the MANIFEST.in kludge we've been doing.