### PR TITLE
build: fix setup.py to include sub-packages

### DIFF
--- a/python-template/{{cookiecutter.placeholder_repo_name}}/setup.py
+++ b/python-template/{{cookiecutter.placeholder_repo_name}}/setup.py
@@ -128,7 +128,7 @@ setup(
     author_email='oscm@edx.org',
     url='https://github.com/edx/{{ cookiecutter.repo_name }}',
     packages=find_packages(
-        include=['{{ cookiecutter.sub_dir_name }}'],
+        include=['{{ cookiecutter.sub_dir_name }}', '{{ cookiecutter.sub_dir_name }}.*'],
         exclude=["*tests"],
     ),
     include_package_data=True,


### PR DESCRIPTION
This fixes the previous commit,
which accidentally limited `find_packages`
to only finding the root package
instead of the root package and all of its
subpackages.

I found this issue and confirmed the fix
via this PR, which makes a similar change
in Blockstore: https://github.com/openedx/blockstore/pull/202
