### PR TITLE
chore: Add Dockerfile linter

### DIFF
--- a/.github/workflows/dockerfile-lint.yml
+++ b/.github/workflows/dockerfile-lint.yml
@@ -1,0 +1,14 @@
+name: Dockerfile Lint
+on: [push]
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps: 
+    - name: Checkout
+      uses: actions/checkout@master
+    - name: lint
+      uses: luke142367/Docker-Lint-Action@v1.0.0
+      with:
+        target: cookiecutter-django-ida/{{cookiecutter.repo_name}}/Dockerfile
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dockerfile-lint.yml
+++ b/.github/workflows/dockerfile-lint.yml
@@ -7,7 +7,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@master
     - name: lint
-      uses: luke142367/Docker-Lint-Action@v1.0.0
+      uses: luke142367/Docker-Lint-Action@5c4c86226f39785a66827bbc2e322600c9afa3a9 # v1.1.1
       with:
         target: cookiecutter-django-ida/{{cookiecutter.repo_name}}/Dockerfile
       env:


### PR DESCRIPTION
This PR is an attempt at testing out a fairly nascent linter and is being added due to a Slack converstion with SRE.

See https://github.com/openedx/edx-cookiecutters/pull/267 for competing linter

Currently we review dockerfiles by pasting them into https://www.fromlatest.io/#/ and reading https://2u-internal.atlassian.net/wiki/spaces/SRE/pages/19265642/Dockerfile+Best+Practices at 2U.

Docs:
https://github.com/marketplace/actions/docker-lint (16 stars)
Maintainer:
https://github.com/luke142367 (4th year at Imperial College London)

Next steps:
1. Address the three findings
2. Consider adding an rc file based on https://github.com/replicatedhq/dockerfilelint#configuring