### PR TITLE
fix: fix pull translations command

### DIFF
--- a/cookiecutter-django-app/{{cookiecutter.repo_name}}/Makefile
+++ b/cookiecutter-django-app/{{cookiecutter.repo_name}}/Makefile
@@ -92,7 +92,7 @@ detect_changed_source_translations:
 	cd {{cookiecutter.app_name}} && i18n_tool changed
 
 pull_translations: ## pull translations from Transifex
-	tx pull -af --mode reviewed
+	tx pull -af -t --mode reviewed
 
 push_translations: ## push source translation files (.po) from Transifex
 	tx push -s

--- a/cookiecutter-django-ida/{{cookiecutter.repo_name}}/Makefile
+++ b/cookiecutter-django-ida/{{cookiecutter.repo_name}}/Makefile
@@ -132,7 +132,7 @@ compile_translations: # compile translation files, outputting .po files for each
 fake_translations: ## generate and compile dummy translation files
 
 pull_translations: ## pull translations from Transifex
-	tx pull -af --mode reviewed
+	tx pull -af -t --mode reviewed
 
 push_translations: ## push source translation files (.po) from Transifex
 	tx push -s


### PR DESCRIPTION
### Description 

- `transifex` latest version requires `-t` flag with `tx pull` command so updating the templates to include the parameter by default.