### PR TITLE
fix: a couple of fixes so that `make upgrade` works on a freshly-cut repo

### DIFF
--- a/cookiecutter-django-ida/{{cookiecutter.repo_name}}/Makefile
+++ b/cookiecutter-django-ida/{{cookiecutter.repo_name}}/Makefile
@@ -110,9 +110,9 @@ upgrade: ## update the requirements/*.txt files with the latest packages satisfy
 	$(PIP_COMPILE) -o requirements/test.txt requirements/test.in
 	$(PIP_COMPILE) -o requirements/doc.txt requirements/doc.in
 	$(PIP_COMPILE) -o requirements/quality.txt requirements/quality.in
+	$(PIP_COMPILE) -o requirements/validation.txt requirements/validation.in
 	$(PIP_COMPILE) -o requirements/ci.txt requirements/ci.in
 	$(PIP_COMPILE) -o requirements/dev.txt requirements/dev.in
-	$(PIP_COMPILE) -o requirements/validation.txt requirements/validation.in
 	$(PIP_COMPILE) -o requirements/production.txt requirements/production.in
 	# Let tox control the Django version for tests
 	grep -e "^django==" requirements/base.txt > requirements/django.txt

--- a/cookiecutter-django-ida/{{cookiecutter.repo_name}}/requirements/test.in
+++ b/cookiecutter-django-ida/{{cookiecutter.repo_name}}/requirements/test.in
@@ -1,5 +1,6 @@
 # Requirements for test runs.
 
+-c constraints.txt
 -r base.txt               # Core dependencies for this package
 
 code-annotations


### PR DESCRIPTION
1. The test.in requirements should be constrained by constraints.txt, in addition to base.txt, in case there are common constraints that base would not require but that test.in would (e.g. tox).
2. validation.txt must be compiled before dev.in is compiled into dev.txt, since the latter depends on the former.

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed
