### PR TITLE
fix: address several issues that instantly fail quality tests

### DIFF
--- a/cookiecutter-django-app/{{cookiecutter.repo_name}}/docs/conf.py
+++ b/cookiecutter-django-app/{{cookiecutter.repo_name}}/docs/conf.py
@@ -123,7 +123,14 @@ language = 'en'
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This patterns also effect to html_static_path and html_extra_path
-exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+exclude_patterns = [
+    '_build',
+    'Thumbs.db',
+    '.DS_Store',
+    # This file is intended as a guide for developers browsing the source tree,
+    # not to be rendered into the output docs.
+    'decisions/README.rst',
+]
 
 # The reST default role (used for this markup: `text`) to use for all
 # documents.

--- a/cookiecutter-django-ida/{{cookiecutter.repo_name}}/{{cookiecutter.project_name}}/apps/core/admin.py
+++ b/cookiecutter-django-ida/{{cookiecutter.repo_name}}/{{cookiecutter.project_name}}/apps/core/admin.py
@@ -2,7 +2,7 @@
 
 from django.contrib import admin
 from django.contrib.auth.admin import UserAdmin
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from {{cookiecutter.project_name}}.apps.core.models import User
 

--- a/cookiecutter-django-ida/{{cookiecutter.repo_name}}/{{cookiecutter.project_name}}/apps/core/models.py
+++ b/cookiecutter-django-ida/{{cookiecutter.repo_name}}/{{cookiecutter.project_name}}/apps/core/models.py
@@ -2,7 +2,7 @@
 
 from django.contrib.auth.models import AbstractUser
 from django.db import models
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 
 class User(AbstractUser):

--- a/python-template/{{cookiecutter.placeholder_repo_name}}/docs/conf.py
+++ b/python-template/{{cookiecutter.placeholder_repo_name}}/docs/conf.py
@@ -133,7 +133,14 @@ language = 'en'
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This patterns also effect to html_static_path and html_extra_path
-exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+exclude_patterns = [
+    '_build',
+    'Thumbs.db',
+    '.DS_Store',
+    # This file is intended as a guide for developers browsing the source tree,
+    # not to be rendered into the output docs.
+    'decisions/README.rst',
+]
 
 # The reST default role (used for this markup: `text`) to use for all
 # documents.

--- a/python-template/{{cookiecutter.placeholder_repo_name}}/setup.cfg
+++ b/python-template/{{cookiecutter.placeholder_repo_name}}/setup.cfg
@@ -3,6 +3,8 @@ include_trailing_comma = True
 indent = '    '
 line_length = 120
 multi_line_output = 3
+skip=
+    migrations
 
 [wheel]
 universal = 1


### PR DESCRIPTION
These changes are determined during the process of using this cookiecutter to create a new django app, and getting the output to pass tests.  Changes include:

* Replace `ugettext_lazy` with `gettext_lazy` (the latter is compatible with Django 4+).
* Force Sphinx to ignore `decisions/README.rst` so that pydocstyle doesn't complain about it not having a header.  This file doesn't appear to be intended for output anyway.
* Force isort to skip migration files.  This was already the case for django IDAs, but was missed for django apps.

**Description:**

Describe in a couple of sentences what this PR adds

**JIRA:**

[XXX-XXXX](https://openedx.atlassian.net/browse/XXX-XXXX)

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed
