### PR TITLE
Dockerfile converted into multistage

### DIFF
--- a/cookiecutter-django-ida/{{cookiecutter.repo_name}}/Dockerfile
+++ b/cookiecutter-django-ida/{{cookiecutter.repo_name}}/Dockerfile
@@ -55,25 +55,25 @@ WORKDIR /edx/app/{{cookiecutter.repo_name}}
 
 RUN mkdir -p /edx/var/log
 
-# Code is owned by root so it cannot be modified by the application user.
-# So we copy it before changing users.
-USER app
-
 FROM app as dev
 ENV DJANGO_SETTINGS_MODULE {{cookiecutter.project_name}}.settings.devstack
 
 # Copy the requirements explicitly even though we copy everything below
 # this prevents the image cache from busting unless the dependencies have changed.
-COPY requirements/development.txt /edx/app/{{cookiecutter.repo_name}}/requirements/development.txt
+COPY requirements/dev.txt /edx/app/{{cookiecutter.repo_name}}/requirements/dev.txt
 
 # Dependencies are installed as root so they cannot be modified by the application user.
-RUN pip install -r requirements/development.txt
+RUN pip install -r requirements/dev.txt
 
 CMD while true; do python ./manage.py runserver 0.0.0.0:{{cookiecutter.port}}; sleep 2; done
 
 # This line is after the requirements so that changes to the code will not
 # bust the image cache
 COPY . /edx/app/{{cookiecutter.repo_name}}
+
+# Code is owned by root so it cannot be modified by the application user.
+# So we copy it before changing users.
+USER app
 
 
 FROM app as prod
@@ -92,3 +92,7 @@ CMD gunicorn --workers=2 --name {{cookiecutter.repo_name}} -c /edx/app/{{cookiec
 # This line is after the requirements so that changes to the code will not
 # bust the image cache
 COPY . /edx/app/{{cookiecutter.repo_name}}
+
+# Code is owned by root so it cannot be modified by the application user.
+# So we copy it before changing users.
+USER app

--- a/cookiecutter-django-ida/{{cookiecutter.repo_name}}/Dockerfile
+++ b/cookiecutter-django-ida/{{cookiecutter.repo_name}}/Dockerfile
@@ -26,6 +26,7 @@ RUN apt-get update && apt-get -qy install --no-install-recommends \
  locales \
  python3.8 \
  python3-pip \
+ python3-virtualenv \
  libmysqlclient-dev \
  libssl-dev \
  python3-dev \
@@ -42,6 +43,10 @@ RUN locale-gen en_US.UTF-8
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en
 ENV LC_ALL en_US.UTF-8
+ENV COOKIE_CUTTER_VENV_DIR="/edx/app/{{cookiecutter.repo_name}}/venvs/{{cookiecutter.repo_name}}"
+ENV PATH="$COOKIE_CUTTER_VENV_DIR/bin:$PATH"
+RUN virtualenv -p python3.8 --always-copy ${COOKIE_CUTTER_VENV_DIR}
+
 
 EXPOSE {{cookiecutter.port}}
 RUN useradd -m --shell /bin/false app
@@ -64,8 +69,7 @@ COPY requirements/development.txt /edx/app/{{cookiecutter.repo_name}}/requiremen
 # Dependencies are installed as root so they cannot be modified by the application user.
 RUN pip install -r requirements/development.txt
 
-# Gunicorn 19 does not log to stdout or stderr by default. Once we are past gunicorn 19, the logging to STDOUT need not be specified.
-CMD while true; do python ./manage.py runserver 0.0.0.0:8120; sleep 2; done
+CMD while true; do python ./manage.py runserver 0.0.0.0:{{cookiecutter.port}}; sleep 2; done
 
 # This line is after the requirements so that changes to the code will not
 # bust the image cache

--- a/cookiecutter-django-ida/{{cookiecutter.repo_name}}/Dockerfile
+++ b/cookiecutter-django-ida/{{cookiecutter.repo_name}}/Dockerfile
@@ -71,8 +71,6 @@ CMD while true; do python ./manage.py runserver 0.0.0.0:{{cookiecutter.port}}; s
 # bust the image cache
 COPY . /edx/app/{{cookiecutter.repo_name}}
 
-# Code is owned by root so it cannot be modified by the application user.
-# So we copy it before changing users.
 USER app
 
 
@@ -86,13 +84,10 @@ COPY requirements/production.txt /edx/app/{{cookiecutter.repo_name}}/requirement
 # Dependencies are installed as root so they cannot be modified by the application user.
 RUN pip install -r requirements/production.txt
 
-# Gunicorn 19 does not log to stdout or stderr by default. Once we are past gunicorn 19, the logging to STDOUT need not be specified.
 CMD gunicorn --workers=2 --name {{cookiecutter.repo_name}} -c /edx/app/{{cookiecutter.repo_name}}/{{cookiecutter.project_name}}/docker_gunicorn_configuration.py --log-file - --max-requests=1000 {{cookiecutter.project_name}}.wsgi:application
 
 # This line is after the requirements so that changes to the code will not
 # bust the image cache
 COPY . /edx/app/{{cookiecutter.repo_name}}
 
-# Code is owned by root so it cannot be modified by the application user.
-# So we copy it before changing users.
 USER app

--- a/cookiecutter-django-ida/{{cookiecutter.repo_name}}/Dockerfile
+++ b/cookiecutter-django-ida/{{cookiecutter.repo_name}}/Dockerfile
@@ -42,12 +42,38 @@ RUN locale-gen en_US.UTF-8
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en
 ENV LC_ALL en_US.UTF-8
-ENV DJANGO_SETTINGS_MODULE {{cookiecutter.project_name}}.settings.production
 
 EXPOSE {{cookiecutter.port}}
 RUN useradd -m --shell /bin/false app
 
 WORKDIR /edx/app/{{cookiecutter.repo_name}}
+
+RUN mkdir -p /edx/var/log
+
+# Code is owned by root so it cannot be modified by the application user.
+# So we copy it before changing users.
+USER app
+
+FROM app as dev
+ENV DJANGO_SETTINGS_MODULE {{cookiecutter.project_name}}.settings.devstack
+
+# Copy the requirements explicitly even though we copy everything below
+# this prevents the image cache from busting unless the dependencies have changed.
+COPY requirements/development.txt /edx/app/{{cookiecutter.repo_name}}/requirements/development.txt
+
+# Dependencies are installed as root so they cannot be modified by the application user.
+RUN pip install -r requirements/development.txt
+
+# Gunicorn 19 does not log to stdout or stderr by default. Once we are past gunicorn 19, the logging to STDOUT need not be specified.
+CMD while true; do python ./manage.py runserver 0.0.0.0:8120; sleep 2; done
+
+# This line is after the requirements so that changes to the code will not
+# bust the image cache
+COPY . /edx/app/{{cookiecutter.repo_name}}
+
+
+FROM app as prod
+ENV DJANGO_SETTINGS_MODULE {{cookiecutter.project_name}}.settings.production
 
 # Copy the requirements explicitly even though we copy everything below
 # this prevents the image cache from busting unless the dependencies have changed.
@@ -55,12 +81,6 @@ COPY requirements/production.txt /edx/app/{{cookiecutter.repo_name}}/requirement
 
 # Dependencies are installed as root so they cannot be modified by the application user.
 RUN pip install -r requirements/production.txt
-
-RUN mkdir -p /edx/var/log
-
-# Code is owned by root so it cannot be modified by the application user.
-# So we copy it before changing users.
-USER app
 
 # Gunicorn 19 does not log to stdout or stderr by default. Once we are past gunicorn 19, the logging to STDOUT need not be specified.
 CMD gunicorn --workers=2 --name {{cookiecutter.repo_name}} -c /edx/app/{{cookiecutter.repo_name}}/{{cookiecutter.project_name}}/docker_gunicorn_configuration.py --log-file - --max-requests=1000 {{cookiecutter.project_name}}.wsgi:application

--- a/cookiecutter-django-ida/{{cookiecutter.repo_name}}/Makefile
+++ b/cookiecutter-django-ida/{{cookiecutter.repo_name}}/Makefile
@@ -152,7 +152,8 @@ detect_changed_source_translations: ## check if translation files are up-to-date
 validate_translations: fake_translations detect_changed_source_translations ## install fake translations and check if translation files are up-to-date
 
 docker_build:
-	docker build . -f Dockerfile -t openedx/{{cookiecutter.repo_name}}
+	docker build . -f Dockerfile --target prod -t openedx/{{cookiecutter.repo_name}}
+	docker build . -f Dockerfile --target dev -t openedx/{{cookiecutter.repo_name}}-dev
 
 # devstack-themed shortcuts
 dev.up: # Starts all containers
@@ -183,10 +184,12 @@ db-shell: # Run the app shell as root, enter the app's database
 	docker attach {{cookiecutter.project_name}}.$*
 
 github_docker_build:
-	docker build . -f Dockerfile --target app -t openedx/{{cookiecutter.repo_name}}
+	docker build . -f Dockerfile --target prod -t openedx/{{cookiecutter.repo_name}}
+	docker build . -f Dockerfile --target dev -t openedx/{{cookiecutter.repo_name}}-dev
 
 github_docker_tag: github_docker_build
 	docker tag openedx/{{cookiecutter.repo_name}} openedx/{{cookiecutter.repo_name}}:${GITHUB_SHA}
+	docker tag openedx/{{cookiecutter.repo_name}}-dev openedx/{{cookiecutter.repo_name}}-dev:${GITHUB_SHA}
 
 github_docker_auth:
 	echo "$$DOCKERHUB_PASSWORD" | docker login -u "$$DOCKERHUB_USERNAME" --password-stdin
@@ -194,6 +197,7 @@ github_docker_auth:
 github_docker_push: github_docker_tag github_docker_auth ## push to docker hub
 	docker push 'openedx/{{cookiecutter.repo_name}}:latest'
 	docker push "openedx/{{cookiecutter.repo_name}}:${GITHUB_SHA}"
+	docker push "openedx/{{cookiecutter.repo_name}}-dev:${GITHUB_SHA}"
 
 selfcheck: ## check that the Makefile is well-formed
 	@echo "The Makefile is well-formed."


### PR DESCRIPTION
**Description:**

Added two stages dev and prod target in Dockerfile.

**Steps to test**
- Clone the repo
- Checkout to zshkoor/multi-stage-dockerfile branch
- Use this command to createe an IDA
`cookiecutter -o /path/to/folder/for/creating/project cookiecutter-django-ida`
- Now go to project's root and run `make upgrade` to prepare requirements files
- Now run `make docker_build` to make test image build

**Issue:**

https://github.com/openedx/edx-cookiecutters/issues/292

**Merge checklist:**
- [ ] All reviewers approved
- [x] CI build is green
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [x] Commits are squashed
