### PR TITLE
fix: Remove `default_app_config` from app template (dropped in Django 4)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,14 @@ Change Log
    This file loosely adheres to the structure of https://keepachangelog.com/,
    but in reStructuredText instead of Markdown.
 
+2023-04-14
+**********
+
+Fixed
+=====
+
+- Removed ``default_app_config`` from django-app cookiecutter output's dunder-init file (deprecated in Django 3, removed in Django 4)
+
 2023-04-11
 **********
 

--- a/cookiecutter-django-app/{{cookiecutter.repo_name}}/{{cookiecutter.app_name}}/__init__.py
+++ b/cookiecutter-django-app/{{cookiecutter.repo_name}}/{{cookiecutter.app_name}}/__init__.py
@@ -3,5 +3,3 @@
 """
 
 __version__ = '{{ cookiecutter.version }}'
-
-default_app_config = '{{ cookiecutter.app_name }}.apps.{{ cookiecutter.config_class_name }}'  # pylint: disable=invalid-name

--- a/tests/test_cookiecutter_django_app.py
+++ b/tests/test_cookiecutter_django_app.py
@@ -120,12 +120,15 @@ def test_github_actions_ci():
     assert 'pip install -r requirements/ci.txt' in ci_text
 
 
-def test_app_config(options_baked):
-    """The generated Django AppConfig should look correct."""
+def test_dunder_init(options_baked):
+    """The generated init file should have at least the version string."""
     init_text = Path("cookie_lover/__init__.py").read_text()
-    pattern = r"^default_app_config = 'cookie_lover.apps.CookieLoverConfig'  #"
+    pattern = r"^__version__ = "
     assert re.search(pattern, init_text, re.MULTILINE)
 
+
+def test_app_config(options_baked):
+    """The generated Django AppConfig should have an AppConfig subclass."""
     apps_text = Path("cookie_lover/apps.py").read_text()
     pattern = r'^class CookieLoverConfig\(AppConfig\):$'
     assert re.search(pattern, apps_text, re.MULTILINE)


### PR DESCRIPTION
As of version 3, Django is able to autodetect the AppConfig in apps.py: https://docs.djangoproject.com/en/3.2/ref/applications/

In 4.0+ it relies on this and does not read `default_app_config` at all.


**Merge checklist:**
Check off if complete *or* not applicable:
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Fixup commits are squashed away
- [x] Unit tests added/updated
- [x] Manual testing instructions provided
- [x] Noted any: Concerns, dependencies, deadlines, tickets
