### PR TITLE
build: update tx config templates for transifex v3

### DIFF
--- a/cookiecutter-django-ida/{{cookiecutter.repo_name}}/.tx/config
+++ b/cookiecutter-django-ida/{{cookiecutter.repo_name}}/.tx/config
@@ -1,14 +1,14 @@
 [main]
 host = https://www.transifex.com
 
-[edx-platform.{{cookiecutter.repo_name}}]
+[o:open-edx:p:edx-platform:r:{{cookiecutter.repo_name}}]
 file_filter = {{cookiecutter.project_name}}/conf/locale/<lang>/LC_MESSAGES/django.po
 source_file = {{cookiecutter.project_name}}/conf/locale/en/LC_MESSAGES/django.po
 source_lang = en
-type = PO
+type        = PO
 
-[edx-platform.{{cookiecutter.repo_name}}-js]
+[o:open-edx:p:edx-platform:r:{{cookiecutter.repo_name}}-js]
 file_filter = {{cookiecutter.project_name}}/conf/locale/<lang>/LC_MESSAGES/djangojs.po
 source_file = {{cookiecutter.project_name}}/conf/locale/en/LC_MESSAGES/djangojs.po
 source_lang = en
-type = PO
+type        = PO

--- a/cookiecutter-xblock/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/.tx/config
+++ b/cookiecutter-xblock/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/.tx/config
@@ -1,3 +1,8 @@
 [main]
 host = https://www.transifex.com
 
+[o:open-edx:p:p:xblocks:r:{{cookiecutter.repo_name}}]
+file_filter = {{cookiecutter.package_name}}/translations/<lang>/LC_MESSAGES/text.po
+source_file = {{cookiecutter.package_name}}/translations/en/LC_MESSAGES/text.po
+source_lang = en
+type        = PO


### PR DESCRIPTION
### Description
- Fixes https://github.com/openedx/edx-cookiecutters/issues/293
- Updated tx config templates for `django-ida` and `xblock` according to transifex client v3. 