### PR TITLE
fix: add extra lines in urls.py docstring to squash sphinx error

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,14 @@ Change Log
    This file loosely adheres to the structure of https://keepachangelog.com/,
    but in reStructuredText instead of Markdown.
 
+2023-04-11
+**********
+
+Changed
+=======
+
+- Added linebreaks to root urls.py docstring for cookiecutter-django-ida to squash Sphinx error.
+
 2023-03-17
 **********
 

--- a/cookiecutter-django-ida/{{cookiecutter.repo_name}}/{{cookiecutter.project_name}}/urls.py
+++ b/cookiecutter-django-ida/{{cookiecutter.repo_name}}/{{cookiecutter.project_name}}/urls.py
@@ -3,13 +3,17 @@
 
 The `urlpatterns` list routes URLs to views. For more information please see:
     https://docs.djangoproject.com/en/3.2/topics/http/urls/
+
 Examples:
+
 Function views
     1. Add an import:  from my_app import views
     2. Add a URL to urlpatterns:  url(r'^$', views.home, name='home')
+
 Class-based views
     1. Add an import:  from other_app.views import Home
     2. Add a URL to urlpatterns:  url(r'^$', Home.as_view(), name='home')
+
 Including another URLconf
     1. Add an import:  from blog import urls as blog_urls
     2. Add a URL to urlpatterns:  url(r'^blog/', include(blog_urls))


### PR DESCRIPTION
Get the following errors when running `make html` on a brand new cookiecutter-django-ida template:

    .../urls.py:docstring of commerce_coordinator.urls:5: WARNING: Definition list ends without a blank line; unexpected unindent.
    .../urls.py:docstring of commerce_coordinator.urls:7: ERROR: Unexpected indentation.
    .../urls.py:docstring of commerce_coordinator.urls:9: WARNING: Block quote ends without a blank line; unexpected unindent.

Add linebreaks to squash error.


**Merge checklist:**
Check off if complete *or* not applicable:
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Fixup commits are squashed away
- [x] Unit tests added/updated
- [x] Manual testing instructions provided
- [x] Noted any: Concerns, dependencies, deadlines, tickets
