### PR TITLE
build: remove deprecated codecov CI package in requirements/ci.in

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,7 @@ Change Log
 Changed
 =======
 
+- Remove deprecated codecov CI package in requirements/ci.in
 - Added linebreaks to root urls.py docstring for cookiecutter-django-ida to squash Sphinx error.
 
 2023-03-17

--- a/cookiecutter-django-app/{{cookiecutter.repo_name}}/requirements/ci.in
+++ b/cookiecutter-django-app/{{cookiecutter.repo_name}}/requirements/ci.in
@@ -2,6 +2,5 @@
 
 -c constraints.txt
 
-codecov                   # Code coverage reporting
 tox                       # Virtualenv management for tests
 tox-battery               # Makes tox aware of requirements file changes

--- a/cookiecutter-django-ida/{{cookiecutter.repo_name}}/requirements/ci.in
+++ b/cookiecutter-django-ida/{{cookiecutter.repo_name}}/requirements/ci.in
@@ -2,6 +2,5 @@
 
 -c constraints.txt
 
-codecov                   # Code coverage reporting
 tox                       # Virtualenv management for tests
 tox-battery               # Makes tox aware of requirements file changes

--- a/cookiecutter-xblock/{{cookiecutter.repo_name}}/requirements/ci.in
+++ b/cookiecutter-xblock/{{cookiecutter.repo_name}}/requirements/ci.in
@@ -2,6 +2,5 @@
 
 -c constraints.txt
 
-codecov                   # Code coverage reporting
 tox                       # Virtualenv management for tests
 tox-battery               # Makes tox aware of requirements file changes

--- a/python-template/{{cookiecutter.placeholder_repo_name}}/requirements/ci.in
+++ b/python-template/{{cookiecutter.placeholder_repo_name}}/requirements/ci.in
@@ -1,5 +1,4 @@
 # Requirements for running tests on CI
 -c constraints.txt
 
-codecov                   # Code coverage reporting
 tox                       # Virtualenv management for tests


### PR DESCRIPTION
The codecov PyPI package is now deprecated. See:

https://community.codecov.com/t/codecov-yanked-from-pypi-all-versions/4259

Its presence in our requirements files are currently causing a lot of CI failures.

It is replaced by codecov-action, a GitHub Action that will upload coverage results to Codecov.

codecov-action is already in edx-cookiecutters in the .github/workflow folder of python-template, on which all other cookiecutters currently depend.


**Merge checklist:**
Check off if complete *or* not applicable:
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Fixup commits are squashed away
- [x] Unit tests added/updated
- [x] Manual testing instructions provided
- [x] Noted any: Concerns, dependencies, deadlines, tickets
