### PR TITLE
fix: Stop using deprecated project path getter

### DIFF
--- a/test_utils/bake.py
+++ b/test_utils/bake.py
@@ -34,5 +34,5 @@ def bake_in_temp_dir(cookies, *args, **kwargs):
     result = cookies.bake(*args, **kwargs)
     if result.exception:
         raise result.exception
-    with inside_dir(str(result.project)):
+    with inside_dir(str(result.project_path)):
         yield


### PR DESCRIPTION
This was causing warnings from `pytest_cookies` during test runs.


**Merge checklist:**
Check off if complete *or* not applicable:
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Fixup commits are squashed away
- [x] Unit tests added/updated
- [x] Manual testing instructions provided
- [x] Noted any: Concerns, dependencies, deadlines, tickets
