### PR TITLE
fix: changelogs shouldn't have square brackets around the version number 

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,14 @@ Change Log
    This file loosely adheres to the structure of https://keepachangelog.com/,
    but in reStructuredText instead of Markdown.
 
+2023-04-18
+**********
+
+Fixed
+=====
+
+- Corrected the punctuation of changelog entries.
+
 2023-04-14
 **********
 

--- a/python-template/{{cookiecutter.placeholder_repo_name}}/CHANGELOG.rst
+++ b/python-template/{{cookiecutter.placeholder_repo_name}}/CHANGELOG.rst
@@ -16,8 +16,8 @@ Unreleased
 
 *
 
-[{{ cookiecutter.version }}] - {% now 'local' %}
-************************************************
+{{ cookiecutter.version }} – {% now 'local' %}
+**********************************************
 
 Added
 =====


### PR DESCRIPTION
keepachangelog.com has them because their example is a Markdown file where the version numbers are short-links to a git diff of the changes. Our version numbers are not links.


**Merge checklist:**
Check off if complete *or* not applicable:
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Fixup commits are squashed away
- [ ] Unit tests added/updated
- [ ] Manual testing instructions provided
- [ ] Noted any: Concerns, dependencies, deadlines, tickets
