### PR TITLE
refactor: Make post_gen_project hooks as similar as possible

### DIFF
--- a/cookiecutter-django-app/hooks/post_gen_project.py
+++ b/cookiecutter-django-app/hooks/post_gen_project.py
@@ -34,12 +34,12 @@ def move(src, dest):
 # Use Python template to get python files
 
 # output location for python-template cookiecutter
-python_placeholder_repo_name = "placeholder_repo_name_0"
+placeholder_repo_name = "placeholder_repo_name_0"
 
 extra_context = {}
 extra_context["repo_name"] = "{{cookiecutter.repo_name}}"
-extra_context["sub_dir_name"] = "{{cookiecutter.app_name}}"
 extra_context["project_name"] = "{{cookiecutter.project_name}}"
+extra_context["sub_dir_name"] = "{{cookiecutter.app_name}}"
 extra_context["project_short_description"] = "{{cookiecutter.project_short_description}}"
 extra_context["version"] = "{{cookiecutter.version}}"
 extra_context["author_name"] = "{{cookiecutter.author_name}}"
@@ -47,7 +47,7 @@ extra_context["author_email"] = "{{cookiecutter.author_email}}"
 extra_context["open_source_license"] = "{{cookiecutter.open_source_license}}"
 extra_context["requires_django"] = "yes"
 
-extra_context["placeholder_repo_name"] = python_placeholder_repo_name
+extra_context["placeholder_repo_name"] = placeholder_repo_name
 
 cookiecutter(
     EDX_COOKIECUTTER_ROOTDIR,
@@ -56,14 +56,16 @@ cookiecutter(
     directory='python-template',
 )
 
-
 # moving templated cookie-cutter output to root
 project_root_dir = os.getcwd()
-python_cookiecutter_output_loc = os.path.join(project_root_dir, extra_context["placeholder_repo_name"])
+python_cookiecutter_output_loc = os.path.join(project_root_dir, placeholder_repo_name)
 files = os.listdir(python_cookiecutter_output_loc)
+
 for f in files:
     move(os.path.join(python_cookiecutter_output_loc, f), os.path.join(project_root_dir, f))
 
 # removing temp dir created by templated cookiecutter
 os.rmdir(python_cookiecutter_output_loc)
+
+# Post build fixes
 write_main(['pylintrc'])

--- a/cookiecutter-django-ida/hooks/post_gen_project.py
+++ b/cookiecutter-django-ida/hooks/post_gen_project.py
@@ -47,7 +47,7 @@ def remove(path):
 # Use Python template to get python files
 
 # output location for python-template cookiecutter
-python_placeholder_repo_name = "placeholder_repo_name_0"
+placeholder_repo_name = "placeholder_repo_name_0"
 
 extra_context = {}
 extra_context["repo_name"] = "{{cookiecutter.repo_name}}"
@@ -60,7 +60,7 @@ extra_context["author_email"] = "{{cookiecutter.author_email}}"
 extra_context["open_source_license"] = "{{cookiecutter.open_source_license}}"
 extra_context["if_features_docs"] = "yes"
 
-extra_context["placeholder_repo_name"] = python_placeholder_repo_name
+extra_context["placeholder_repo_name"] = placeholder_repo_name
 
 cookiecutter(
     EDX_COOKIECUTTER_ROOTDIR,
@@ -69,17 +69,20 @@ cookiecutter(
     directory='python-template',
 )
 
+# moving templated cookie-cutter output to root
 project_root_dir = os.getcwd()
-python_template_cookiecutter_output_loc = os.path.join(project_root_dir, python_placeholder_repo_name)
-files = os.listdir(python_template_cookiecutter_output_loc)
+python_cookiecutter_output_loc = os.path.join(project_root_dir, placeholder_repo_name)
+files = os.listdir(python_cookiecutter_output_loc)
 
 for f in files:
-    move(os.path.join(python_template_cookiecutter_output_loc, f), os.path.join(project_root_dir, f))
+    move(os.path.join(python_cookiecutter_output_loc, f), os.path.join(project_root_dir, f))
 
-os.rmdir(python_template_cookiecutter_output_loc)
+# removing temp dir created by templated cookiecutter
+os.rmdir(python_cookiecutter_output_loc)
 
 # Removing unecessary files from python and django templates:
 remove("setup.py")
 remove("MANIFEST.in")
 
+# Post build fixes
 write_main(['pylintrc'])

--- a/cookiecutter-python-library/hooks/post_gen_project.py
+++ b/cookiecutter-python-library/hooks/post_gen_project.py
@@ -31,18 +31,22 @@ def move(src, dest):
         shutil.move(src, dest)
 
 
-# Using the template to create things
+# Use Python template to get python files
+
+# output location for python-template cookiecutter
+placeholder_repo_name = "placeholder_repo_name_0"
+
 extra_context = {}
 extra_context["repo_name"] = "{{cookiecutter.repo_name}}"
-extra_context["sub_dir_name"] = "{{cookiecutter.library_name}}"
 extra_context["project_name"] = "{{cookiecutter.project_name}}"
+extra_context["sub_dir_name"] = "{{cookiecutter.library_name}}"
 extra_context["project_short_description"] = "{{cookiecutter.project_short_description}}"
 extra_context["version"] = "{{cookiecutter.version}}"
 extra_context["author_name"] = "{{cookiecutter.author_name}}"
 extra_context["author_email"] = "{{cookiecutter.author_email}}"
 extra_context["open_source_license"] = "{{cookiecutter.open_source_license}}"
 
-extra_context["placeholder_repo_name"] = "placeholder_repo_name"
+extra_context["placeholder_repo_name"] = placeholder_repo_name
 
 cookiecutter(
     EDX_COOKIECUTTER_ROOTDIR,
@@ -53,7 +57,7 @@ cookiecutter(
 
 # moving templated cookie-cutter output to root
 project_root_dir = os.getcwd()
-python_cookiecutter_output_loc = os.path.join(project_root_dir, extra_context["placeholder_repo_name"])
+python_cookiecutter_output_loc = os.path.join(project_root_dir, placeholder_repo_name)
 files = os.listdir(python_cookiecutter_output_loc)
 
 for f in files:

--- a/cookiecutter-xblock/hooks/post_gen_project.py
+++ b/cookiecutter-xblock/hooks/post_gen_project.py
@@ -31,7 +31,11 @@ def move(src, dest):
         shutil.move(src, dest)
 
 
-# Using the template to create things
+# Use Python template to get python files
+
+# output location for python-template cookiecutter
+placeholder_repo_name = "placeholder_repo_name_0"
+
 extra_context = {}
 extra_context["repo_name"] = "{{cookiecutter.repo_name}}"
 extra_context["project_name"] = "{{cookiecutter.repo_name}}"
@@ -50,7 +54,8 @@ setup_py_keyword_args = """entry_points={
     package_data=package_data("{{cookiecutter.package_name}}", ["static", "public"]),
 """
 extra_context["setup_py_keyword_args"] = setup_py_keyword_args
-extra_context["placeholder_repo_name"] = "placeholder_repo_name"
+
+extra_context["placeholder_repo_name"] = placeholder_repo_name
 
 cookiecutter(
     EDX_COOKIECUTTER_ROOTDIR,
@@ -61,7 +66,7 @@ cookiecutter(
 
 # moving templated cookie-cutter output to root
 project_root_dir = os.getcwd()
-python_cookiecutter_output_loc = os.path.join(project_root_dir, extra_context["placeholder_repo_name"])
+python_cookiecutter_output_loc = os.path.join(project_root_dir, placeholder_repo_name)
 files = os.listdir(python_cookiecutter_output_loc)
 
 for f in files:


### PR DESCRIPTION
The post_gen hooks have diverged somewhat, which makes it harder to see what can be extracted and deduplicated -- and what is actually supposed to differ between the cookiecutters.

This commit brings the files more closely into alignment:

- Naming of placeholder dir (ADR 3 actually specifies the name) and use of a variable to deduplicate it within the file (xblock, library)
- Line breaks and comments (all)
- Ordering of project/sub_dir in extra_context (app, library)
- Remove `template_` from name of temp dir (ida)
- Remove `python_` from name of placeholder dir variable (app, ida)


**Merge checklist:**
Check off if complete *or* not applicable:
- [ ] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Fixup commits are squashed away
- [x] Unit tests added/updated
- [x] Manual testing instructions provided
- [x] Noted any: Concerns, dependencies, deadlines, tickets
