### PR TITLE
fix: correct .coveragerc omitted files globs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,14 @@ Change Log
    This file loosely adheres to the structure of https://keepachangelog.com/,
    but in reStructuredText instead of Markdown.
 
+2023-05-04
+**********
+
+Fixed
+=====
+
+- Correct .coveragerc ``omit`` file paths to properly specify directories.
+
 2023-05-03
 **********
 

--- a/cookiecutter-django-app/{{cookiecutter.repo_name}}/.coveragerc
+++ b/cookiecutter-django-app/{{cookiecutter.repo_name}}/.coveragerc
@@ -3,8 +3,8 @@ branch = True
 data_file = .coverage
 source={{cookiecutter.app_name}}
 omit =
-    test_settings
-    *migrations*
+    test_settings.py
+    */migrations/*
     *admin.py
-    *static*
-    *templates*
+    */static/*
+    */templates/*

--- a/cookiecutter-django-ida/{{cookiecutter.repo_name}}/.coveragerc
+++ b/cookiecutter-django-ida/{{cookiecutter.repo_name}}/.coveragerc
@@ -3,10 +3,10 @@ branch = True
 data_file = .coverage
 source={{cookiecutter.project_name}}
 omit =
-    {{cookiecutter.project_name}}/settings*
-    {{cookiecutter.project_name}}/conf*
+    {{cookiecutter.project_name}}/settings/*
+    {{cookiecutter.project_name}}/conf/*
     *wsgi.py
-    *migrations*
+    */migrations/*
     *admin.py
-    *static*
-    *templates*
+    */static/*
+    */templates/*


### PR DESCRIPTION
See https://coverage.readthedocs.io/en/7.2.5/migrating.html & Ned's note in comments of this PR.

----

Via testing, I suspect that:

* Coverage.py file patterns only matches entire directories if the file pattern ends with a slash and asterisk ("/*").

* In addition to the rule above, Coverage.py file patterns that start with a wildcard character only matches entire directories if the file pattern starts with an asterisk and slash ("*/").

Example:

    % python
    Python 3.8.11 (default, Aug 23 2021, 18:14:59)
    >>> import coverage
    >>> coverage.version_info
    (7, 2, 3, 'final', 0)
    >>> from coverage.files import GlobMatcher
    >>> GlobMatcher(["*migrations*"], "omit").match("/dir/project/migrations/0001_initial.py")
    False
    >>> GlobMatcher(["*/migrations/*"], "omit").match("/dir/project/migrations/0001_initial.py")
    True
    >>> GlobMatcher(["/dir/project/settings*"], "omit").match("/dir/project/settings/base.py")
    False
    >>> GlobMatcher(["/dir/project/settings/*"], "omit").match("/dir/project/settings/base.py")
    True
    >>> GlobMatcher(["*admin.py"], "omit").match("/dir/project/app/app_name/admin.py")
    True

See:

* [InOrOut.check_include_omit_etc()](https://github.com/nedbat/coveragepy/blob/cf3602ffa7396d8f784c1a1e814ff24c6c31f793/coverage/inorout.py#L444)
* [GlobMatcher in self.omit](https://github.com/nedbat/coveragepy/blob/cf3602ffa7396d8f784c1a1e814ff24c6c31f793/coverage/inorout.py#L253)
* [Definition of self.omit](https://github.com/nedbat/coveragepy/blob/cf3602ffa7396d8f784c1a1e814ff24c6c31f793/coverage/inorout.py#L205)
* [Coverage.py glob documentation](https://coverage.readthedocs.io/en/7.2.5/source.html#file-patterns)

This PR corrects .coveragerc files so they omit files they intend to omit.

-----

**Merge checklist:**
Check off if complete *or* not applicable:
- [X] Changelog record added
- [X] Documentation updated (not only docstrings)
- [X] Fixup commits are squashed away
- [X] Unit tests added/updated
- [X] Manual testing instructions provided
- [X] Noted any: Concerns, dependencies, deadlines, tickets
