### PR TITLE
docs: Update the place where the docs will be published.

### DIFF
--- a/python-template/{{cookiecutter.placeholder_repo_name}}/README.rst
+++ b/python-template/{{cookiecutter.placeholder_repo_name}}/README.rst
@@ -174,7 +174,7 @@ Please do not report security issues in public. Please email security@tcril.org.
     :alt: Codecov
 
 .. |doc-badge| image:: https://readthedocs.org/projects/{{ cookiecutter.repo_name }}/badge/?version=latest
-    :target: https://{{ cookiecutter.repo_name }}.readthedocs.io/en/latest/
+    :target: https://docs.openedx.org/projects/{{ cookiecutter.repo_name }}
     :alt: Documentation
 
 .. |pyversions-badge| image:: https://img.shields.io/pypi/pyversions/{{ cookiecutter.repo_name }}.svg


### PR DESCRIPTION
For new apps and libraries, we'll be publishing their docs under the
single docs.openedx.org domain and not under separate subdomains.
Update the template so that it defaults to that for the docs URL.
