### PR TITLE
docs: don't assume virtualenvwrapper

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -32,20 +32,22 @@ Using the cookiecutters
   git clone git@github.com:openedx/edx-cookiecutters.git
   cd edx-cookiecutters
 
-  # Set up a virtualenv using virtualenvwrapper with the same name as the repo and activate it
-  mkvirtualenv -p python3.8 edx-cookiecutters
+  # Set up a virtualenv.
+  python3.8 -m venv venv
+  make requirements
 
 2. Create a cookiecutter Repository
 ===================================
+.. code-block::
 
-These instructions assume you have cloned this repository and are currently in its head dir. You will need a virtualenv for running the cookiecutter. You can discard it once the cookiecutter has made your new repo.
+    # Activate your virtualenv and ensure requirements are up-to-date.
+    . venv/bin/activate
+    make requirements
 
-Commands::
-
-    $ make requirements  # from inside edx-cookiecutter repo
+    # Run the cookiecutter.
     # Replace <OUTPUT-DIRECTORY> with the base directory; your new directory will go inside.
     # Replace <COOKIECUTTER-NAME> with one of the available cookiecutters documented above.
-    $ cookiecutter -o <OUTPUT-DIRECTORY> <COOKIECUTTER-NAME>
+    cookiecutter -o <OUTPUT-DIRECTORY> <COOKIECUTTER-NAME>
 
 3. TODOs after running cookiecutter
 ===================================
@@ -73,10 +75,9 @@ Directions for contributing to this repository
   git clone git@github.com:openedx/edx-cookiecutters.git
   cd edx-cookiecutters
 
-  # Set up a virtualenv using virtualenvwrapper with the same name as the repo and activate it
-  mkvirtualenv -p python3.8 edx-cookiecutters
-  # Activate the virtualenv
-  workon edx-cookiecutters
+  # Set up a virtualenv and activate it
+  python3.8 -m venv venv
+  . venv/bin/activate
 
   # Grab the latest code
   git checkout master

--- a/cookiecutter-django-app/README.rst
+++ b/cookiecutter-django-app/README.rst
@@ -55,7 +55,8 @@ Enter the project and take a look around::
 Generate a virtualenv and generate requirements files with dependencies
 pinned to current versions (make sure you're using pip 9.0.2+ and Python 3.8)::
 
-    $ mkvirtualenv Blogging-for-humans
+    $ python3.8 -m venv venv
+    $ . venv/bin/activate
     $ make upgrade
 
 Create a GitHub repo and push it there::
@@ -92,9 +93,11 @@ Code has been written, but does it actually work? Let's find out!
 
 ::
 
-    workon <YOURVIRTUALENV>
-    (myenv) $ make requirements
-    (myenv) $ make test-all
+    
+    python3.8 -m venv venv  # Make a virtual env, if you haven't already.
+    . venv/bin/activate     # Active it.
+    make requirements       # Install Python dependencies.
+    make test-all           # Run tests.
 
 
 Github Checks

--- a/python-template/{{cookiecutter.placeholder_repo_name}}/README.rst
+++ b/python-template/{{cookiecutter.placeholder_repo_name}}/README.rst
@@ -36,8 +36,8 @@ One Time Setup
   git clone git@github.com:openedx/{{ cookiecutter.repo_name }}.git
   cd {{ cookiecutter.repo_name }}
 
-  # Set up a virtualenv using virtualenvwrapper with the same name as the repo and activate it
-  mkvirtualenv -p python3.8 {{ cookiecutter.repo_name }}
+  # Set up a virtualenv
+  python3.8 -m venv venv
 
 
 Every time you develop something in this repo
@@ -45,7 +45,7 @@ Every time you develop something in this repo
 .. code-block::
 
   # Activate the virtualenv
-  workon {{ cookiecutter.repo_name }}
+  . venv/bin/activate
 
   # Grab the latest code
   git checkout main

--- a/python-template/{{cookiecutter.placeholder_repo_name}}/docs/getting_started.rst
+++ b/python-template/{{cookiecutter.placeholder_repo_name}}/docs/getting_started.rst
@@ -1,10 +1,19 @@
 Getting Started
 ###############
 
-If you have not already done so, create/activate a `virtualenv`_. Unless otherwise stated, assume all terminal code
+If you have not already done so, create/activate a `virtualenv`_::
+
+    python3.8 -m venv venv
+    . venv/bin/activate
+
+Alternatively, many folks choose to use the `virtualenvwrapper`_
+library to streamline virtualenv management across their system.
+
+Unless otherwise stated, assume all terminal code
 below is executed within the virtualenv.
 
-.. _virtualenv: https://virtualenvwrapper.readthedocs.org/en/latest/
+.. _virtualenv: https://docs.python.org/3/library/venv.html
+.. _virtualenvwrapper: https://virtualenvwrapper.readthedocs.io/en/latest/
 
 
 Install dependencies
@@ -13,6 +22,6 @@ Dependencies can be installed via the command below.
 
 .. code-block:: bash
 
-    $ make requirements
+    make requirements
 
 


### PR DESCRIPTION
`workon` and `mkvirtualenv` are tools from the virtualenvwrapper Python library.

Not everyone installs this library, and we don't ask them to, so we should just use the build-in Python venv feature, and let virtualenvwrapper users adapt the instructions as they see fit.


**Merge checklist:**
Check off if complete *or* not applicable:
- [ ] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Fixup commits are squashed away
- [x] Unit tests added/updated
- [x] Manual testing instructions provided
- [ ] Noted any: Concerns, dependencies, deadlines, tickets
