### PR TITLE
build: no need to pin arrow anymore

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,10 +4,8 @@
 #
 #    make upgrade
 #
-arrow==0.13.2
-    # via
-    #   -c requirements/constraints.txt
-    #   jinja2-time
+arrow==1.2.3
+    # via jinja2-time
 astroid==2.15.5
     # via
     #   pylint

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -11,9 +11,6 @@
 # Common constraints for edx repos
 -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
  
-# Imposed by pytest-cookies 0.5.1 to continue supporting Python 3.4
-arrow<0.14.0
-
 # doc8==1.0.0 requires docutils>=0.19 but sphinx_rtd_theme latest version requires <0.18
 doc8<1.0.0
 

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -12,9 +12,8 @@ alabaster==0.7.13
     # via
     #   -r requirements/test.txt
     #   sphinx
-arrow==0.13.2
+arrow==1.2.3
     # via
-    #   -c requirements/constraints.txt
     #   -r requirements/test.txt
     #   jinja2-time
 asgiref==3.7.2
@@ -52,10 +51,6 @@ certifi==2023.5.7
     # via
     #   -r requirements/test.txt
     #   requests
-cffi==1.15.1
-    # via
-    #   -r requirements/test.txt
-    #   cryptography
 chardet==5.1.0
     # via
     #   -r requirements/test.txt
@@ -85,10 +80,6 @@ cookiecutter==2.1.1
     # via
     #   -r requirements/test.txt
     #   pytest-cookies
-cryptography==41.0.1
-    # via
-    #   -r requirements/test.txt
-    #   secretstorage
 dill==0.3.6
     # via
     #   -r requirements/test.txt
@@ -160,11 +151,6 @@ jaraco-classes==3.2.3
     # via
     #   -r requirements/test.txt
     #   keyring
-jeepney==0.8.0
-    # via
-    #   -r requirements/test.txt
-    #   keyring
-    #   secretstorage
 jinja2==3.1.2
     # via
     #   -r requirements/test.txt
@@ -242,10 +228,6 @@ py==1.11.0
     #   tox
 pycodestyle==2.10.0
     # via -r requirements/test.txt
-pycparser==2.21
-    # via
-    #   -r requirements/test.txt
-    #   cffi
 pydata-sphinx-theme==0.13.3
     # via
     #   -r requirements/test.txt
@@ -338,10 +320,6 @@ rich==13.4.1
     # via
     #   -r requirements/test.txt
     #   twine
-secretstorage==3.3.3
-    # via
-    #   -r requirements/test.txt
-    #   keyring
 sh==2.0.4
     # via -r requirements/test.txt
 six==1.16.0

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -8,9 +8,8 @@ accessible-pygments==0.0.4
     # via pydata-sphinx-theme
 alabaster==0.7.13
     # via sphinx
-arrow==0.13.2
+arrow==1.2.3
     # via
-    #   -c requirements/constraints.txt
     #   -r requirements/base.txt
     #   jinja2-time
 asgiref==3.7.2
@@ -38,8 +37,6 @@ certifi==2023.5.7
     # via
     #   -r requirements/base.txt
     #   requests
-cffi==1.15.1
-    # via cryptography
 chardet==5.1.0
     # via
     #   -r requirements/base.txt
@@ -67,8 +64,6 @@ cookiecutter==2.1.1
     # via
     #   -r requirements/base.txt
     #   pytest-cookies
-cryptography==41.0.1
-    # via secretstorage
 dill==0.3.6
     # via
     #   -r requirements/base.txt
@@ -124,10 +119,6 @@ isort==5.12.0
     #   pylint
 jaraco-classes==3.2.3
     # via keyring
-jeepney==0.8.0
-    # via
-    #   keyring
-    #   secretstorage
 jinja2==3.1.2
     # via
     #   -r requirements/base.txt
@@ -180,8 +171,6 @@ pluggy==1.0.0
     # via pytest
 pycodestyle==2.10.0
     # via -r requirements/test.in
-pycparser==2.21
-    # via cffi
 pydata-sphinx-theme==0.13.3
     # via sphinx-book-theme
 pydocstyle==6.3.0
@@ -255,8 +244,6 @@ rfc3986==2.0.0
     # via twine
 rich==13.4.1
     # via twine
-secretstorage==3.3.3
-    # via keyring
 sh==2.0.4
     # via -r requirements/test.in
 six==1.16.0


### PR DESCRIPTION
The constraint mentioned 3.4, and old arrow was producing these warnings:

```
tests/test_cookiecutter_django_app.py::test_bake_selecting_license[AGPL 3.0-GNU AFFERO GENERAL PUBLIC LICENSE]
  .../edx-cookiecutters/.tox/py38/lib/python3.8/site-packages/arrow/parser.py:24: DeprecationWarning: invalid escape sequence \[
    _ESCAPE_RE = re.compile('\[[^\[\]]*\]')
```


**Merge checklist:**
Check off if complete *or* not applicable:
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Fixup commits are squashed away
- [x] Unit tests added/updated
- [x] Manual testing instructions provided
- [x] Noted any: Concerns, dependencies, deadlines, tickets
