### PR TITLE
feat: Install pkg-config for IDA Dockerfile

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,14 @@ Change Log
    This file loosely adheres to the structure of https://keepachangelog.com/,
    but in reStructuredText instead of Markdown.
 
+2023-07-07
+**********
+
+Fixed
+=====
+
+- Include ``pkg-config`` in apt-installed packages in IDA Dockerfile, allowing upgrade to mysqlclient 2.2.0
+
 2023-06-21
 **********
 

--- a/cookiecutter-django-ida/{{cookiecutter.repo_name}}/Dockerfile
+++ b/cookiecutter-django-ida/{{cookiecutter.repo_name}}/Dockerfile
@@ -21,14 +21,11 @@ MAINTAINER sre@edx.org
 # gcc; for compiling python extensions distributed with python packages like mysql-client
 
 # If you add a package here please include a comment above describing what it is used for
-RUN apt-get update && apt-get -qy install --no-install-recommends \
- language-pack-en \
- locales \
- python3.8 \
- python3-pip \
- libmysqlclient-dev \
- libssl-dev \
- python3-dev \
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -qy install --no-install-recommends \
+ language-pack-en locales \
+ python3.8 python3-dev python3-pip \
+ # The mysqlclient Python package has install-time dependencies
+ libmysqlclient-dev libssl-dev pkg-config \
  gcc
 
 


### PR DESCRIPTION
mysqlclient 2.2.0 requires Debian package pkg-config to be installed. In some Dockerfiles this also leads to tzdata being installed, which prompts for config and causes the image build to hang, so add `DEBIAN_FRONTEND=noninteractive` to prevent the prompt.

Also organize packages by general purpose. (Would be nice to have comments on all of the groups, but might as well start with this one.)

Fixes https://github.com/openedx/edx-cookiecutters/issues/363


**Merge checklist:**
Check off if complete *or* not applicable:
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Fixup commits are squashed away
- [x] Unit tests added/updated
- [x] Manual testing instructions provided
- [x] Noted any: Concerns, dependencies, deadlines, tickets
