### PR TITLE
chore: Update mysql version from 5.6 to 8.0 for cookie cutter

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,14 @@ Change Log
    This file loosely adheres to the structure of https://keepachangelog.com/,
    but in reStructuredText instead of Markdown.
 
+2023-08-01
+**********
+
+Changed
+=======
+
+- Update mysql docker image from 5.6 to 8.0 to use the newest LTS version of the mysql server
+
 2023-07-07
 **********
 

--- a/cookiecutter-django-ida/{{cookiecutter.repo_name}}/docker-compose.yml
+++ b/cookiecutter-django-ida/{{cookiecutter.repo_name}}/docker-compose.yml
@@ -1,9 +1,10 @@
 version: "2.1"
 services:
   db:
-    image: mysql:5.6
+    image: mysql:8.0
     container_name: {{cookiecutter.project_name}}.db
     environment:
+      # See how these environment variables being used at https://github.com/mysql/mysql-docker/blob/mysql-server/8.0/docker-entrypoint.sh
       MYSQL_ROOT_PASSWORD: ""
       MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
     networks:


### PR DESCRIPTION
Update the mysql version of the cookie cutter to use mysql 8.0 docker container
**Merge checklist:**
Check off if complete *or* not applicable:
- [x] Changelog record added
- [x] Fixup commits are squashed away

