### PR TITLE
fix: Don't filter out extras for a pip dependency.

### DIFF
--- a/python-template/{{cookiecutter.placeholder_repo_name}}/setup.py
+++ b/python-template/{{cookiecutter.placeholder_repo_name}}/setup.py
@@ -40,7 +40,7 @@ def load_requirements(*requirements_paths):
     constraint_files = set()
 
     # groups "pkg<=x.y.z,..." into ("pkg", "<=x.y.z,...")
-    requirement_line_regex = re.compile(r"([a-zA-Z0-9-_.]+)([<>=][^#\s]+)?")
+    requirement_line_regex = re.compile(r"([a-zA-Z0-9-_.\[\]]+)([<>=][^#\s]+)?")
 
     def add_version_constraint_or_raise(current_line, current_requirements, add_if_not_present):
         regex_match = requirement_line_regex.match(current_line)

--- a/scripts/update_setup_py.sh
+++ b/scripts/update_setup_py.sh
@@ -43,7 +43,7 @@ echo -e "rules:
         constraint_files = set()
 
         # groups \"my-package-name<=x.y.z,...\" into (\"my-package-name\", \"<=x.y.z,...\")
-        requirement_line_regex = re.compile(r\"([a-zA-Z0-9-_.]+)([<>=][^#\s]+)?\")
+        requirement_line_regex = re.compile(r\"([a-zA-Z0-9-_.\[\]]+)([<>=][^#\s]+)?\")
 
         def add_version_constraint_or_raise(current_line, current_requirements, add_if_not_present):
             regex_match = requirement_line_regex.match(current_line)


### PR DESCRIPTION
Before this change, the function was dropping extra dependencies. For
example:

If you had a requirements file like the following:
```
Xblock[django]
```

It will output: `Xblock`

The correct output should be `Xblock[django]`

This drops the extras which may have further constraint requirements or
more packages that are required. In the example, the package would need
Django but that dependency would not be visible upstream correctly.