### PR TITLE
feat: non-openedx repos get instructions to find tweaks

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,12 @@ Change Log
    This file loosely adheres to the structure of https://keepachangelog.com/,
    but in reStructuredText instead of Markdown.
 
+2023-08-11
+**********
+
+- Added: When a repo is made outside of the openedx GitHub organization, the
+  post hook tells the user to go find changes that need to be made.
+
 2023-08-01
 **********
 

--- a/lib/src/edx_cookiecutter_lib/post_code.py
+++ b/lib/src/edx_cookiecutter_lib/post_code.py
@@ -62,3 +62,12 @@ def post_gen_project(extra_context):
 
     # Post build fixes
     write_main(['pylintrc'])
+
+    # Cookiecutters are right for the openedx organization. Other orgs might need
+    # adjustments.
+    org = extra_context["github_org"]
+    if org != "openedx":
+        print("*" * 78)
+        print(f"Since your repo will be in the {org} organization, you may need")
+        print("to adjust the contents of the repo, such as licenses, email addresses,")
+        print("and contribution details. Check with your organization.")


### PR DESCRIPTION
This prompts users to seek org-specific tweaks when they aren't making repos in the openedx organization.  Axim would prefer not to have private wiki links in public tools, so we don't link to specific instructions like https://2u-internal.atlassian.net/wiki/spaces/ENG/pages/493453499/Repo+deltas+for+edx+GitHub+repos .

I tried to write a test for this, but could not figure out how to capture the stdout from the post hook. 

**Merge checklist:**
Check off if complete *or* not applicable:
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Fixup commits are squashed away
- [ ] Unit tests added/updated
- [ ] Manual testing instructions provided
- [ ] Noted any: Concerns, dependencies, deadlines, tickets
