### PR TITLE
feat: Support multiple extras in requirements constraint advertisement

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,7 +5,7 @@ Change Log
    This file loosely adheres to the structure of https://keepachangelog.com/,
    but in reStructuredText instead of Markdown.
 
-2023-08-15
+2023-08-16
 **********
 
 Changed

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,7 +12,7 @@ Changed
 =======
 
 - In setup.py, support advertising constraints on packages with multiple extras
-- Fail packaging if requirements are spelled differently in different places
+- Fail packaging if requirements are named differently in different places or have different extras listed
 
 2023-08-11
 **********

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,15 @@ Change Log
    This file loosely adheres to the structure of https://keepachangelog.com/,
    but in reStructuredText instead of Markdown.
 
+2023-08-15
+**********
+
+Changed
+=======
+
+- In setup.py, support advertising constraints on packages with multiple extras
+- Fail packaging if requirements are spelled differently in different places
+
 2023-08-11
 **********
 

--- a/python-template/{{cookiecutter.placeholder_repo_name}}/setup.py
+++ b/python-template/{{cookiecutter.placeholder_repo_name}}/setup.py
@@ -36,7 +36,7 @@ def load_requirements(*requirements_paths):
     with -c in the requirements files.
     Returns a list of requirement strings.
     """
-    # e.g. {"django": "Django", "openedx-events": "openedx_events"}
+    # e.g. {"django": "Django", "confluent-kafka": "confluent_kafka[avro]"}
     by_canonical_name = {}
 
     def check_name_consistent(package):

--- a/python-template/{{cookiecutter.placeholder_repo_name}}/setup.py
+++ b/python-template/{{cookiecutter.placeholder_repo_name}}/setup.py
@@ -63,8 +63,9 @@ def load_requirements(*requirements_paths):
 
     # groups "pkg<=x.y.z,..." into ("pkg", "<=x.y.z,...")
     re_package_name_base_chars = r"a-zA-Z0-9\-_."  # chars allowed in base package name
+    # Two groups: name[maybe,extras], and optionally a constraint
     requirement_line_regex = re.compile(
-        r"([%s]+(?:\[[%s,\s]+\])?)([<>=][^#\s]+)?"  # name[maybe,extras] and maybe constraint
+        r"([%s]+(?:\[[%s,\s]+\])?)([<>=][^#\s]+)?"
         % (re_package_name_base_chars, re_package_name_base_chars)
     )
 

--- a/python-template/{{cookiecutter.placeholder_repo_name}}/setup.py
+++ b/python-template/{{cookiecutter.placeholder_repo_name}}/setup.py
@@ -36,17 +36,43 @@ def load_requirements(*requirements_paths):
     with -c in the requirements files.
     Returns a list of requirement strings.
     """
+    by_canonical_name = {}
+
+    def check_name_consistent(package):
+        """
+        Raise exception if package is spelled different ways.
+
+        This ensures that packages are spelled consistently so we can match
+        constraints to packages. It also ensures that if we require a package
+        with extras we don't constrain it without mentioning the extras (since
+        that too would interfere with matching constraints.)
+        """
+        canonical = package.lower().replace('_', '-').split('[')[0]
+        seen_spelling = by_canonical_name[canonical]
+        if seen_spelling is None:
+            by_canonical_name[canonical] = package
+        elif seen_spelling != package:
+            raise Exception(
+                f'Encountered both "{seen_spelling}" and "{package}" in requirements '
+                'and constraints files; please use just one or the other.'
+            )
+
     requirements = {}
     constraint_files = set()
 
     # groups "pkg<=x.y.z,..." into ("pkg", "<=x.y.z,...")
-    requirement_line_regex = re.compile(r"([a-zA-Z0-9-_.\[\]]+)([<>=][^#\s]+)?")
+    re_package_name_base_chars = r"a-zA-Z0-9\-_."  # chars allowed in base package name
+    requirement_line_regex = re.compile(
+        r"([%s]+(?:\[[%s,\s]+\])?)([<>=][^#\s]+)?"
+        % (re_package_name_base_chars, re_package_name_base_chars)
+    )
 
     def add_version_constraint_or_raise(current_line, current_requirements, add_if_not_present):
         regex_match = requirement_line_regex.match(current_line)
         if regex_match:
             package = regex_match.group(1)
             version_constraints = regex_match.group(2)
+            check_name_consistent(package)
             existing_version_constraints = current_requirements.get(package, None)
             # It's fine to add constraints to an unconstrained package,
             # but raise an error if there are already constraints in place.

--- a/python-template/{{cookiecutter.placeholder_repo_name}}/setup.py
+++ b/python-template/{{cookiecutter.placeholder_repo_name}}/setup.py
@@ -48,7 +48,7 @@ def load_requirements(*requirements_paths):
         that too would interfere with matching constraints.)
         """
         canonical = package.lower().replace('_', '-').split('[')[0]
-        seen_spelling = by_canonical_name[canonical]
+        seen_spelling = by_canonical_name.get(canonical)
         if seen_spelling is None:
             by_canonical_name[canonical] = package
         elif seen_spelling != package:

--- a/python-template/{{cookiecutter.placeholder_repo_name}}/setup.py
+++ b/python-template/{{cookiecutter.placeholder_repo_name}}/setup.py
@@ -36,13 +36,14 @@ def load_requirements(*requirements_paths):
     with -c in the requirements files.
     Returns a list of requirement strings.
     """
+    # e.g. {"django": "Django", "openedx-events": "openedx_events"}
     by_canonical_name = {}
 
     def check_name_consistent(package):
         """
-        Raise exception if package is spelled different ways.
+        Raise exception if package is named different ways.
 
-        This ensures that packages are spelled consistently so we can match
+        This ensures that packages are named consistently so we can match
         constraints to packages. It also ensures that if we require a package
         with extras we don't constrain it without mentioning the extras (since
         that too would interfere with matching constraints.)
@@ -63,7 +64,7 @@ def load_requirements(*requirements_paths):
     # groups "pkg<=x.y.z,..." into ("pkg", "<=x.y.z,...")
     re_package_name_base_chars = r"a-zA-Z0-9\-_."  # chars allowed in base package name
     requirement_line_regex = re.compile(
-        r"([%s]+(?:\[[%s,\s]+\])?)([<>=][^#\s]+)?"
+        r"([%s]+(?:\[[%s,\s]+\])?)([<>=][^#\s]+)?"  # name[maybe,extras] and maybe constraint
         % (re_package_name_base_chars, re_package_name_base_chars)
     )
 

--- a/scripts/update_setup_py.sh
+++ b/scripts/update_setup_py.sh
@@ -50,8 +50,8 @@ fi
 echo -e "[ARCHBOM-1772](https://openedx.atlassian.net/browse/ARCHBOM-1772)
  Update setup.py to use constraint files when generating requirements files for packaging and distribution.
  PR generated automatically with Jenkins job cleanup-python-code. " > .git/cleanup-python-code-description
-echo -e "\nResult of running \`python setup.py bdist_wheel\` before applying fix (in .egg-info/requires.txt)\: \n" >> .git/cleanup-python-code-description
+echo -e "\nResult of running \`python setup.py bdist_wheel\` before applying fix (in .egg-info/requires.txt): \n" >> .git/cleanup-python-code-description
 cat ./update-setup-tmp/old_requires.txt >> .git/cleanup-python-code-description
-echo -e "\nResult of running \`python setup.py bdist_wheel\` after applying fix (in .egg-info/requires.txt)\: \n" >> .git/cleanup-python-code-description
+echo -e "\nResult of running \`python setup.py bdist_wheel\` after applying fix (in .egg-info/requires.txt): \n" >> .git/cleanup-python-code-description
 cat "$(pwd)/$wheel_dir/requires.txt" >> .git/cleanup-python-code-description
 rm -rf update-setup-tmp

--- a/scripts/update_setup_py_load_requirements.yaml
+++ b/scripts/update_setup_py_load_requirements.yaml
@@ -17,18 +17,43 @@ rules:
         Returns a list of requirement strings.
         """
         # UPDATED VIA SEMGREP - if you need to remove/modify this method remove this line and add a comment specifying why.
+        by_canonical_name = {}
+
+        def check_name_consistent(package):
+            """
+            Raise exception if package is spelled different ways.
+
+            This ensures that packages are spelled consistently so we can match
+            constraints to packages. It also ensures that if we require a package
+            with extras we don't constrain it without mentioning the extras (since
+            that too would interfere with matching constraints.)
+            """
+            canonical = package.lower().replace('_', '-').split('[')[0]
+            seen_spelling = by_canonical_name[canonical]
+            if seen_spelling is None:
+                by_canonical_name[canonical] = package
+            elif seen_spelling != package:
+                raise Exception(
+                    f'Encountered both "{seen_spelling}" and "{package}" in requirements '
+                    'and constraints files; please use just one or the other.'
+                )
 
         requirements = {}
         constraint_files = set()
 
         # groups "pkg<=x.y.z,..." into ("pkg", "<=x.y.z,...")
-        requirement_line_regex = re.compile(r"([a-zA-Z0-9-_.\[\]]+)([<>=][^#\s]+)?")
+        re_package_name_base_chars = r"a-zA-Z0-9\-_."  # chars allowed in base package name
+        requirement_line_regex = re.compile(
+            r"([%s]+(?:\[[%s,\s]+\])?)([<>=][^#\s]+)?"
+            % (re_package_name_base_chars, re_package_name_base_chars)
+        )
 
         def add_version_constraint_or_raise(current_line, current_requirements, add_if_not_present):
             regex_match = requirement_line_regex.match(current_line)
             if regex_match:
                 package = regex_match.group(1)
                 version_constraints = regex_match.group(2)
+                check_name_consistent(package)
                 existing_version_constraints = current_requirements.get(package, None)
                 # It's fine to add constraints to an unconstrained package,
                 # but raise an error if there are already constraints in place.

--- a/scripts/update_setup_py_load_requirements.yaml
+++ b/scripts/update_setup_py_load_requirements.yaml
@@ -29,7 +29,7 @@ rules:
             that too would interfere with matching constraints.)
             """
             canonical = package.lower().replace('_', '-').split('[')[0]
-            seen_spelling = by_canonical_name[canonical]
+            seen_spelling = by_canonical_name.get(canonical)
             if seen_spelling is None:
                 by_canonical_name[canonical] = package
             elif seen_spelling != package:

--- a/scripts/update_setup_py_load_requirements.yaml
+++ b/scripts/update_setup_py_load_requirements.yaml
@@ -17,13 +17,15 @@ rules:
         Returns a list of requirement strings.
         """
         # UPDATED VIA SEMGREP - if you need to remove/modify this method remove this line and add a comment specifying why.
+
+        # e.g. {"django": "Django", "openedx-events": "openedx_events"}
         by_canonical_name = {}
 
         def check_name_consistent(package):
             """
-            Raise exception if package is spelled different ways.
+            Raise exception if package is named different ways.
 
-            This ensures that packages are spelled consistently so we can match
+            This ensures that packages are named consistently so we can match
             constraints to packages. It also ensures that if we require a package
             with extras we don't constrain it without mentioning the extras (since
             that too would interfere with matching constraints.)
@@ -43,6 +45,7 @@ rules:
 
         # groups "pkg<=x.y.z,..." into ("pkg", "<=x.y.z,...")
         re_package_name_base_chars = r"a-zA-Z0-9\-_."  # chars allowed in base package name
+        # Two groups: name[maybe,extras], and optionally a constraint
         requirement_line_regex = re.compile(
             r"([%s]+(?:\[[%s,\s]+\])?)([<>=][^#\s]+)?"
             % (re_package_name_base_chars, re_package_name_base_chars)

--- a/scripts/update_setup_py_load_requirements.yaml
+++ b/scripts/update_setup_py_load_requirements.yaml
@@ -18,7 +18,7 @@ rules:
         """
         # UPDATED VIA SEMGREP - if you need to remove/modify this method remove this line and add a comment specifying why.
 
-        # e.g. {"django": "Django", "openedx-events": "openedx_events"}
+        # e.g. {"django": "Django", "confluent-kafka": "confluent_kafka[avro]"}
         by_canonical_name = {}
 
         def check_name_consistent(package):


### PR DESCRIPTION
Update the base template's setup.py to support the full syntax of package extras.

- Support commas and whitespace inside extras declarations, e.g. `some_package[extra_one, extra_two]`
- Raise exception if we spell packages differently in requirement and constraint files, including presence/absence of extras.


**Merge checklist:**
Check off if complete *or* not applicable:
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Fixup commits are squashed away
- [ ] Unit tests added/updated
- [x] Manual testing instructions provided
- [ ] Noted any: Concerns, dependencies, deadlines, tickets
