### PR TITLE
Various improvements to setup.py updater

### DIFF
--- a/python-template/{{cookiecutter.placeholder_repo_name}}/setup.py
+++ b/python-template/{{cookiecutter.placeholder_repo_name}}/setup.py
@@ -48,8 +48,8 @@ def load_requirements(*requirements_paths):
             package = regex_match.group(1)
             version_constraints = regex_match.group(2)
             existing_version_constraints = current_requirements.get(package, None)
-            # fine to add constraints to an unconstrained package,
-            # raise an error if there are already constraints in place
+            # It's fine to add constraints to an unconstrained package,
+            # but raise an error if there are already constraints in place.
             if existing_version_constraints and existing_version_constraints != version_constraints:
                 raise BaseException(f'Multiple constraint definitions found for {package}:'
                                     f' "{existing_version_constraints}" and "{version_constraints}".'
@@ -58,8 +58,8 @@ def load_requirements(*requirements_paths):
             if add_if_not_present or package in current_requirements:
                 current_requirements[package] = version_constraints
 
-    # read requirements from .in
-    # store the path to any constraint files that are pulled in
+    # Read requirements from .in files and store the path to any
+    # constraint files that are pulled in.
     for path in requirements_paths:
         with open(path) as reqs:
             for line in reqs:

--- a/scripts/update_setup_py.sh
+++ b/scripts/update_setup_py.sh
@@ -9,24 +9,24 @@
 
 script_home=$(dirname -- "${BASH_SOURCE[0]}")
 
-mkdir update-setup-tmp;
+mkdir update-setup-tmp
 
 # generate and store requires.txt file for future comparison
-python setup.py bdist_wheel;
-wheel_dir=$(find . -name *.egg-info | xargs basename);
-cp "$(pwd)/$wheel_dir/requires.txt" ./update-setup-tmp/old_requires.txt;
+python setup.py bdist_wheel
+wheel_dir=$(find . -name *.egg-info | xargs basename)
+cp "$(pwd)/$wheel_dir/requires.txt" ./update-setup-tmp/old_requires.txt
 
 # make sure os and re are imported in setup.py, and remove any direct imports of os.path.dirname to avoid conflict
-isort --rm "import os.path.dirname" -a "import os re" setup.py;
+isort --rm "import os.path.dirname" -a "import os re" setup.py
 
 # Need two separate config files, one for each method being overriden,
 # in order to avoid collisions when doing code replacement
 # --debug will provide additional logging in case things fail
-semgrep -a --config="$script_home"/update_setup_py_load_requirements.yaml --debug setup.py;
-semgrep -a --config="$script_home"/update_setup_py_is_requirement.yaml --debug setup.py;
+semgrep -a --config="$script_home"/update_setup_py_load_requirements.yaml --debug setup.py
+semgrep -a --config="$script_home"/update_setup_py_is_requirement.yaml --debug setup.py
 
 # rerun packaging command to generate new requires.txt file
-python setup.py bdist_wheel;
+python setup.py bdist_wheel
 
 # add constraints file to manifest so python tests pass
 # note: this will not work for repositories where the constraints file has been changed from requirements/constraints.txt
@@ -43,9 +43,9 @@ fi
 # Create PR description for use by cleanup-python-code jenkins job
 echo -e "[ARCHBOM-1772](https://openedx.atlassian.net/browse/ARCHBOM-1772)
  Update setup.py to use constraint files when generating requirements files for packaging and distribution.
- PR generated automatically with Jenkins job cleanup-python-code. " > .git/cleanup-python-code-description;
-echo -e "\nResult of running \`python setup.py bdist_wheel\` before applying fix (in .egg-info/requires.txt)\: \n" >> .git/cleanup-python-code-description;
-cat ./update-setup-tmp/old_requires.txt >> .git/cleanup-python-code-description;
-echo -e "\nResult of running \`python setup.py bdist_wheel\` after applying fix (in .egg-info/requires.txt)\: \n" >> .git/cleanup-python-code-description;
-cat "$(pwd)/$wheel_dir/requires.txt" >> .git/cleanup-python-code-description;
+ PR generated automatically with Jenkins job cleanup-python-code. " > .git/cleanup-python-code-description
+echo -e "\nResult of running \`python setup.py bdist_wheel\` before applying fix (in .egg-info/requires.txt)\: \n" >> .git/cleanup-python-code-description
+cat ./update-setup-tmp/old_requires.txt >> .git/cleanup-python-code-description
+echo -e "\nResult of running \`python setup.py bdist_wheel\` after applying fix (in .egg-info/requires.txt)\: \n" >> .git/cleanup-python-code-description
+cat "$(pwd)/$wheel_dir/requires.txt" >> .git/cleanup-python-code-description
 rm -rf update-setup-tmp

--- a/scripts/update_setup_py.sh
+++ b/scripts/update_setup_py.sh
@@ -7,9 +7,15 @@
 # message for complying with conventional commit guidelines.
 # Date: 11/01/2021
 
+set -eu -o pipefail
+
 script_home=$(dirname -- "${BASH_SOURCE[0]}")
 
-mkdir update-setup-tmp
+# Need semgrep, and also want to ensure we're only installing it into
+# a virtualenv and not unexpectedly into the user's home dir.
+"$VIRTUAL_ENV"/bin/pip install semgrep
+
+mkdir -p update-setup-tmp
 
 # generate and store requires.txt file for future comparison
 python setup.py bdist_wheel

--- a/scripts/update_setup_py.sh
+++ b/scripts/update_setup_py.sh
@@ -7,6 +7,8 @@
 # message for complying with conventional commit guidelines.
 # Date: 11/01/2021
 
+script_home=$(dirname -- "${BASH_SOURCE[0]}")
+
 mkdir update-setup-tmp;
 
 # generate and store requires.txt file for future comparison
@@ -17,95 +19,11 @@ cp "$(pwd)/$wheel_dir/requires.txt" ./update-setup-tmp/old_requires.txt;
 # make sure os and re are imported in setup.py, and remove any direct imports of os.path.dirname to avoid conflict
 isort --rm "import os.path.dirname" -a "import os re" setup.py;
 
-# generate config files for semgrep. need to create two separate config files, one for each method being overriden,
+# Need two separate config files, one for each method being overriden,
 # in order to avoid collisions when doing code replacement
-echo -e "rules:
-- id: fix-load_requirements
-  languages:
-    - python
-  pattern: |
-    def load_requirements(...):
-        ...
-  severity: INFO
-  message: Updating load_requirements method with new standard
-  fix: |
-    def load_requirements(*requirements_paths):
-        \"\"\"
-        Load all requirements from the specified requirements files.
-
-        Requirements will include any constraints from files specified
-        with -c in the requirements files.
-        Returns a list of requirement strings.
-        \"\"\"
-        # UPDATED VIA SEMGREP - if you need to remove/modify this method remove this line and add a comment specifying why.
-
-        requirements = {}
-        constraint_files = set()
-
-        # groups \"my-package-name<=x.y.z,...\" into (\"my-package-name\", \"<=x.y.z,...\")
-        requirement_line_regex = re.compile(r\"([a-zA-Z0-9-_.\[\]]+)([<>=][^#\s]+)?\")
-
-        def add_version_constraint_or_raise(current_line, current_requirements, add_if_not_present):
-            regex_match = requirement_line_regex.match(current_line)
-            if regex_match:
-                package = regex_match.group(1)
-                version_constraints = regex_match.group(2)
-                existing_version_constraints = current_requirements.get(package, None)
-                # it's fine to add constraints to an unconstrained package, but raise an error if there are already
-                # constraints in place
-                if existing_version_constraints and existing_version_constraints != version_constraints:
-                    raise BaseException(f'Multiple constraint definitions found for {package}:'
-                                        f' \"{existing_version_constraints}\" and \"{version_constraints}\".'
-                                        f'Combine constraints into one location with {package}'
-                                        f'{existing_version_constraints},{version_constraints}.')
-                if add_if_not_present or package in current_requirements:
-                    current_requirements[package] = version_constraints
-
-        # process .in files and store the path to any constraint files that are pulled in
-        for path in requirements_paths:
-            with open(path) as reqs:
-                for line in reqs:
-                    if is_requirement(line):
-                        add_version_constraint_or_raise(line, requirements, True)
-                    if line and line.startswith('-c') and not line.startswith('-c http'):
-                        constraint_files.add(os.path.dirname(path) + '/' + line.split('#')[0].replace('-c', '').strip())
-
-        # process constraint files and add any new constraints found to existing requirements
-        for constraint_file in constraint_files:
-            with open(constraint_file) as reader:
-                for line in reader:
-                    if is_requirement(line):
-                        add_version_constraint_or_raise(line, requirements, False)
-
-        # process back into list of pkg><=constraints strings
-        constrained_requirements = [f'{pkg}{version or \"\"}' for (pkg, version) in sorted(requirements.items())]
-        return constrained_requirements" > ./update-setup-tmp/load_requirements.yaml;
-
-echo -e "rules:
-- id: fix-is_requirement
-  languages:
-    - python
-  pattern: |
-    def is_requirement(...):
-        ...
-  severity: INFO
-  message: Updating is_requirement method with new standard
-  fix: |
-    def is_requirement(line):
-        \"\"\"
-        Return True if the requirement line is a package requirement.
-
-        Returns:
-            bool: True if the line is not blank, a comment,
-            a URL, or an included file
-        \"\"\"
-        # UPDATED VIA SEMGREP - if you need to remove/modify this method remove this line and add a comment specifying why
-
-        return line and line.strip() and not line.startswith(('-r', '#', '-e', 'git+', '-c'))" > ./update-setup-tmp/is_requirement.yaml;
-
 # --debug will provide additional logging in case things fail
-semgrep -a --config=./update-setup-tmp/load_requirements.yaml --debug setup.py;
-semgrep -a --config=./update-setup-tmp/is_requirement.yaml --debug setup.py;
+semgrep -a --config="$script_home"/update_setup_py_load_requirements.yaml --debug setup.py;
+semgrep -a --config="$script_home"/update_setup_py_is_requirement.yaml --debug setup.py;
 
 # rerun packaging command to generate new requires.txt file
 python setup.py bdist_wheel;

--- a/scripts/update_setup_py_is_requirement.yaml
+++ b/scripts/update_setup_py_is_requirement.yaml
@@ -1,0 +1,21 @@
+rules:
+- id: fix-is_requirement
+  languages:
+    - python
+  pattern: |
+    def is_requirement(...):
+        ...
+  severity: INFO
+  message: Updating is_requirement method with new standard
+  fix: |
+    def is_requirement(line):
+        """
+        Return True if the requirement line is a package requirement.
+
+        Returns:
+            bool: True if the line is not blank, a comment,
+            a URL, or an included file
+        """
+        # UPDATED VIA SEMGREP - if you need to remove/modify this method remove this line and add a comment specifying why
+
+        return line and line.strip() and not line.startswith(('-r', '#', '-e', 'git+', '-c'))

--- a/scripts/update_setup_py_load_requirements.yaml
+++ b/scripts/update_setup_py_load_requirements.yaml
@@ -21,7 +21,7 @@ rules:
         requirements = {}
         constraint_files = set()
 
-        # groups "my-package-name<=x.y.z,..." into ("my-package-name", "<=x.y.z,...")
+        # groups "pkg<=x.y.z,..." into ("pkg", "<=x.y.z,...")
         requirement_line_regex = re.compile(r"([a-zA-Z0-9-_.\[\]]+)([<>=][^#\s]+)?")
 
         def add_version_constraint_or_raise(current_line, current_requirements, add_if_not_present):
@@ -30,8 +30,8 @@ rules:
                 package = regex_match.group(1)
                 version_constraints = regex_match.group(2)
                 existing_version_constraints = current_requirements.get(package, None)
-                # it's fine to add constraints to an unconstrained package, but raise an error if there are already
-                # constraints in place
+                # It's fine to add constraints to an unconstrained package,
+                # but raise an error if there are already constraints in place.
                 if existing_version_constraints and existing_version_constraints != version_constraints:
                     raise BaseException(f'Multiple constraint definitions found for {package}:'
                                         f' "{existing_version_constraints}" and "{version_constraints}".'
@@ -40,7 +40,8 @@ rules:
                 if add_if_not_present or package in current_requirements:
                     current_requirements[package] = version_constraints
 
-        # process .in files and store the path to any constraint files that are pulled in
+        # Read requirements from .in files and store the path to any
+        # constraint files that are pulled in.
         for path in requirements_paths:
             with open(path) as reqs:
                 for line in reqs:
@@ -49,7 +50,7 @@ rules:
                     if line and line.startswith('-c') and not line.startswith('-c http'):
                         constraint_files.add(os.path.dirname(path) + '/' + line.split('#')[0].replace('-c', '').strip())
 
-        # process constraint files and add any new constraints found to existing requirements
+        # process constraint files: add constraints to existing requirements
         for constraint_file in constraint_files:
             with open(constraint_file) as reader:
                 for line in reader:

--- a/scripts/update_setup_py_load_requirements.yaml
+++ b/scripts/update_setup_py_load_requirements.yaml
@@ -1,0 +1,61 @@
+rules:
+- id: fix-load_requirements
+  languages:
+    - python
+  pattern: |
+    def load_requirements(...):
+        ...
+  severity: INFO
+  message: Updating load_requirements method with new standard
+  fix: |
+    def load_requirements(*requirements_paths):
+        """
+        Load all requirements from the specified requirements files.
+
+        Requirements will include any constraints from files specified
+        with -c in the requirements files.
+        Returns a list of requirement strings.
+        """
+        # UPDATED VIA SEMGREP - if you need to remove/modify this method remove this line and add a comment specifying why.
+
+        requirements = {}
+        constraint_files = set()
+
+        # groups "my-package-name<=x.y.z,..." into ("my-package-name", "<=x.y.z,...")
+        requirement_line_regex = re.compile(r"([a-zA-Z0-9-_.\[\]]+)([<>=][^#\s]+)?")
+
+        def add_version_constraint_or_raise(current_line, current_requirements, add_if_not_present):
+            regex_match = requirement_line_regex.match(current_line)
+            if regex_match:
+                package = regex_match.group(1)
+                version_constraints = regex_match.group(2)
+                existing_version_constraints = current_requirements.get(package, None)
+                # it's fine to add constraints to an unconstrained package, but raise an error if there are already
+                # constraints in place
+                if existing_version_constraints and existing_version_constraints != version_constraints:
+                    raise BaseException(f'Multiple constraint definitions found for {package}:'
+                                        f' "{existing_version_constraints}" and "{version_constraints}".'
+                                        f'Combine constraints into one location with {package}'
+                                        f'{existing_version_constraints},{version_constraints}.')
+                if add_if_not_present or package in current_requirements:
+                    current_requirements[package] = version_constraints
+
+        # process .in files and store the path to any constraint files that are pulled in
+        for path in requirements_paths:
+            with open(path) as reqs:
+                for line in reqs:
+                    if is_requirement(line):
+                        add_version_constraint_or_raise(line, requirements, True)
+                    if line and line.startswith('-c') and not line.startswith('-c http'):
+                        constraint_files.add(os.path.dirname(path) + '/' + line.split('#')[0].replace('-c', '').strip())
+
+        # process constraint files and add any new constraints found to existing requirements
+        for constraint_file in constraint_files:
+            with open(constraint_file) as reader:
+                for line in reader:
+                    if is_requirement(line):
+                        add_version_constraint_or_raise(line, requirements, False)
+
+        # process back into list of pkg><=constraints strings
+        constrained_requirements = [f'{pkg}{version or ""}' for (pkg, version) in sorted(requirements.items())]
+        return constrained_requirements


### PR DESCRIPTION
See commit messages for details. The big changes are 1) moving the YAML into its own files and 2) ensuring that semgrep is actually installed and used.

Manual testing:

- cd to event-bus-kafka and open a virtualenv
- Run the script from that working directory
- Observe that setup.py has changed
- Observe that `.git/cleanup-python-code-description` exists and that there is no difference in the before/after requires lists it displays

**Merge checklist:**
Check off if complete *or* not applicable:
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Fixup commits are squashed away
- [x] Unit tests added/updated
- [x] Manual testing instructions provided
- [x] Noted any: Concerns, dependencies, deadlines, tickets
