### PR TITLE
feat: Change definition of prod_requirements Makefile target

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,14 @@ Change Log
    This file loosely adheres to the structure of https://keepachangelog.com/,
    but in reStructuredText instead of Markdown.
 
+2023-08-30
+**********
+
+Changed
+=======
+
+- Renamed ``prod_requirements`` Maketarget in new IDAs to ``production-requirements``.
+
 2023-08-23
 **********
 

--- a/cookiecutter-django-ida/{{cookiecutter.repo_name}}/Makefile
+++ b/cookiecutter-django-ida/{{cookiecutter.repo_name}}/Makefile
@@ -1,7 +1,7 @@
 .DEFAULT_GOAL := help
 
 .PHONY: help clean clean_tox docs requirements ci_requirements dev_requirements \
-        validation_requirements doc_requirements prod_requirements static shell \
+        validation_requirements doc_requirements production-requirements static shell \
         test coverage isort_check isort style lint quality pii_check validate \
         migrate html_coverage upgrade extract_translation dummy_translations \
         compile_translations fake_translations pull_translations \
@@ -47,7 +47,7 @@ validation_requirements: piptools ## sync to requirements for testing & code qua
 doc_requirements: piptools
 	pip-sync -q requirements/doc.txt
 
-prod_requirements: piptools ## install requirements for production
+production-requirements: piptools ## install requirements for production
 	pip-sync -q requirements/production.txt
 
 static: ## generate static files


### PR DESCRIPTION
For IDAs, the configuration repo expects the Makefile target to be called production-requirements. This change makes future IDAs consistent with this.


**Merge checklist:**
Check off if complete *or* not applicable:
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Fixup commits are squashed away
- [x] Unit tests added/updated
- [x] Manual testing instructions provided
- [x] Noted any: Concerns, dependencies, deadlines, tickets
