### PR TITLE
feat: FC-0012 - add atlas support for cookiecutter-django-app

### DIFF
--- a/cookiecutter-django-app/{{cookiecutter.repo_name}}/Makefile
+++ b/cookiecutter-django-app/{{cookiecutter.repo_name}}/Makefile
@@ -85,17 +85,26 @@ selfcheck: ## check that the Makefile is well-formed
 
 extract_translations: ## extract strings to be translated, outputting .mo files
 	rm -rf docs/_build
-	cd {{cookiecutter.app_name}} && ../manage.py makemessages -l en -v1 -d django
-	cd {{cookiecutter.app_name}} && ../manage.py makemessages -l en -v1 -d djangojs
+	cd {{cookiecutter.app_name}} && i18n_tool extract --no-segment
 
 compile_translations: ## compile translation files, outputting .po files for each supported language
-	cd {{cookiecutter.app_name}} && ../manage.py compilemessages
+	cd {{cookiecutter.app_name}} && i18n_tool generate
 
 detect_changed_source_translations:
 	cd {{cookiecutter.app_name}} && i18n_tool changed
 
-pull_translations: ## pull translations from Transifex
-	tx pull -af -t --mode reviewed
+ifeq ($(OPENEDX_ATLAS_PULL),)
+pull_translations: ## Pull translations from Transifex
+	tx pull -t -a -f --mode reviewed --minimum-perc=1
+else
+# Experimental: OEP-58 Pulls translations using atlas
+pull_translations:
+	find {{cookiecutter.app_name}}/conf/locale -mindepth 1 -maxdepth 1 -type d -exec rm -r {} \;
+	atlas pull $(OPENEDX_ATLAS_ARGS) translations/{{cookiecutter.repo_name}}/{{cookiecutter.app_name}}/conf/locale:{{cookiecutter.app_name}}/conf/locale
+	python manage.py compilemessages
+
+	@echo "Translations have been pulled via Atlas and compiled."
+endif
 
 push_translations: ## push source translation files (.po) from Transifex
 	tx push -s

--- a/cookiecutter-django-app/{{cookiecutter.repo_name}}/requirements/base.in
+++ b/cookiecutter-django-app/{{cookiecutter.repo_name}}/requirements/base.in
@@ -5,3 +5,5 @@ Django             # Web application framework
 {% if cookiecutter.models != "Comma-separated list of models" -%}
 django-model-utils        # Provides TimeStampedModel abstract base class
 {%- endif %}
+
+openedx-atlas

--- a/cookiecutter-django-app/{{cookiecutter.repo_name}}/{{cookiecutter.app_name}}/templates/{{cookiecutter.app_name}}/base.html
+++ b/cookiecutter-django-app/{{cookiecutter.repo_name}}/{{cookiecutter.app_name}}/templates/{{cookiecutter.app_name}}/base.html
@@ -1,4 +1,8 @@
 {% raw %}
+
+{% load i18n %}
+{% trans "Dummy text to generate a translation (.po) source file. It is safe to delete this line. It is also safe to delete (load i18n) above if there are no other (trans) tags in the file" %}
+
 {% comment %}
 As the developer of this package, don't place anything here if you can help it
 since this allows developers to have interoperability between your template


### PR DESCRIPTION
feat: add atlas support for cookiecutter-django-app

Update cookiecutter-django-app to support atlas for all new apps

This PR prepares the repository to comply with [openedx-translations](https://github.com/openedx/openedx-translations) by doing the following:

**Only for `cookiecutter-django-app`:**
* Use `i18_tool extract` to extract transactions

**How it was tested?**
* Create a django app using the cookiecutter `cookiecutter -o testdir cookiecutter-django-app`
* go to the new app project directory
* Create a virtualenv and upgrade requirements using `make upgrade`
* Install the requirements `make requirements`
* try `make extract_translations`: everything looks fine
* try `make validate`: no errors

References
----------

This pull request is part of the [FC-0012 project](https://openedx.atlassian.net/l/cp/XGS0iCcQ) which is sparked by the [Translation Infrastructure update OEP-58](https://open-edx-proposals.readthedocs.io/en/latest/architectural-decisions/oep-0058-arch-translations-management.html#specification).

Check the links above for full information about the overall project.

Internalization is being rearchitected in Open edX Python, XBlock, Micro-frontend, and other projects. There are a number of immediately visible changes:
 - Remove source and language translations from the repositories, hence no `.json`, `.po` or `.mo` files will be committed into the repos.
 - Add standardized `make extract_translations` in all repositories
 - Push user-facing messages strings into [openedx/openedx-translations](https://github.com/openedx/openedx-translations/).
 - Integrate root repositories with [openedx/openedx-atlas](https://github.com/openedx/openedx-atlas/) to pull translations on build/deploy time

Breaking Changes
----------------

One of the primary goals of the project is to **avoid breaking changes**. If you notice any suspicious code, please raise your concern. But before that, please know the strategy we're following to avoid breaking changes

**For XBlocks:**
 - The standard translation path must be `conf/locale`. Therefore, we are creating a link from `conf/locale` to `translations` so Atlas can find the path without disrupting the current way of having translations locally within the XBlocks
 - [openedx-translations](https://github.com/openedx/openedx-translations) will have a related PR that adds the XBlock to the pipeline. This will not affect the current way of managing/updating translations
 - At the end of the project, a clear change log will be added and all translations will be handled by Atlas. Thus, the local translation will be removed from the repo within the version bump
 - A notification for the community will be published to ensure that everyone knows why translation directories are removed from all repos