### PR TITLE
feat: Link to getting-started instructions rather than templating them

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,14 @@ Change Log
    This file loosely adheres to the structure of https://keepachangelog.com/,
    but in reStructuredText instead of Markdown.
 
+2023-11-02
+**********
+
+Changed
+=======
+
+- Changed "Getting Started" section in templated README to link to new Open edX documentation page.
+
 2023-08-30
 **********
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,13 +5,13 @@ Change Log
    This file loosely adheres to the structure of https://keepachangelog.com/,
    but in reStructuredText instead of Markdown.
 
-2023-11-02
+2023-11-08
 **********
 
 Changed
 =======
 
-- Changed "Getting Started" section in templated README to link to new Open edX documentation page.
+- Changed "Getting Started" section in templated README to link to new Open edX documentation page, and renamed to "Getting Started with Development" to clarify purpose.
 
 2023-08-30
 **********

--- a/python-template/{{cookiecutter.placeholder_repo_name}}/README.rst
+++ b/python-template/{{cookiecutter.placeholder_repo_name}}/README.rst
@@ -25,60 +25,10 @@ project.
 Getting Started
 ***************
 
-Developing
-==========
-
-One Time Setup
---------------
-.. code-block::
-
-  # Clone the repository
-  git clone git@github.com:{{ cookiecutter.github_org }}/{{ cookiecutter.repo_name }}.git
-  cd {{ cookiecutter.repo_name }}
-
-  # Set up a virtualenv with the same name as the repo and activate it
-  # Here's how you might do that if you have virtualenvwrapper setup.
-  mkvirtualenv -p python3.8 {{ cookiecutter.repo_name }}
-
-
-Every time you develop something in this repo
----------------------------------------------
-.. code-block::
-
-  # Activate the virtualenv
-  # Here's how you might do that if you're using virtualenvwrapper.
-  workon {{ cookiecutter.repo_name }}
-
-  # Grab the latest code
-  git checkout main
-  git pull
-
-  # Install/update the dev requirements
-  make requirements
-
-  # Run the tests and quality checks (to verify the status before you make any changes)
-  make validate
-
-  # Make a new branch for your changes
-  git checkout -b <your_github_username>/<short_description>
-
-  # Using your favorite editor, edit the code to make your change.
-  vim ...
-
-  # Run your new tests
-  pytest ./path/to/new/tests
-
-  # Run all the tests and quality checks
-  make validate
-
-  # Commit all your changes
-  git commit ...
-  git push
-
-  # Open a PR and ask for review.
+Please see the Open edX documentation for `guidance on Python development <https://docs.openedx.org/en/latest/developers/how-tos/get-ready-for-python-dev.html>`_ in this repo.
 
 Deploying
-=========
+*********
 
 TODO: How can a new user go about deploying this component? Is it just a few
 commands? Is there a larger how-to that should be linked here?

--- a/python-template/{{cookiecutter.placeholder_repo_name}}/README.rst
+++ b/python-template/{{cookiecutter.placeholder_repo_name}}/README.rst
@@ -22,8 +22,8 @@ organization. It should make clear where this fits in to the overall Open edX
 codebase and should be oriented towards people who are new to the Open edX
 project.
 
-Getting Started
-***************
+Getting Started with Development
+********************************
 
 Please see the Open edX documentation for `guidance on Python development <https://docs.openedx.org/en/latest/developers/how-tos/get-ready-for-python-dev.html>`_ in this repo.
 


### PR DESCRIPTION
See https://github.com/openedx/edx-cookiecutters/issues/396 for details.

Also, promote "Deploying" header, which had previously been under "Getting Started".


**Merge checklist:**
Check off if complete *or* not applicable:
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Fixup commits are squashed away
- [x] Unit tests added/updated
- [x] Manual testing instructions provided
- [x] Noted any: Concerns, dependencies, deadlines, tickets
