### PR TITLE
fix: Correct country typo 🇺🇦

### DIFF
--- a/cookiecutter-django-app/{{cookiecutter.repo_name}}/{{cookiecutter.app_name}}/conf/locale/config.yaml
+++ b/cookiecutter-django-app/{{cookiecutter.repo_name}}/{{cookiecutter.app_name}}/conf/locale/config.yaml
@@ -72,7 +72,7 @@ locales:
     - te  # Telugu
     - th  # Thai
     - tr_TR  # Turkish (Turkey)
-    - uk  # Ukranian
+    - uk  # Ukrainian
     - ur  # Urdu
     - uz  # Uzbek
     - vi  # Vietnamese


### PR DESCRIPTION
**Description:**
Simple edit suggestion to fix a typo in the `config.yaml` file for the `django-app` edx-cookiecutter. Change the descriptive comment for the locale, `uk` from **"Ukranian"** to **"Ukrainian"**, which is the correct demonym for people or things related to Ukraine 🇺🇦.

**Additional:**
- This typo error was raised by [`codespell`](https://github.com/codespell-project/codespell), a tool designed to catch common misspellings in code, running as a pre-commit hook in the code-quality tool, [`pre-commit`](https://github.com/pre-commit/pre-commit).
- For more context, this occurred in my local development environment while building an Open edX, Django app plugin.

Here is the error output from `pre-commit`:
```  zsh
codespell................................................................Failed
- hook id: codespell
- exit code: 65

openedx_plugin_greeting/conf/locale/config.yaml:75: Ukranian ==> Ukrainian
```

**Recommendation:**
Consider using the `pre-commit` automation tool to enable contributors to easily add early CI checks into their local dev environments on each commit.

**Testing:**
This PR does not introduce any code changes to the functional code of this repo.

**Merge checklist:**
Check off if complete *or* not applicable:
- [✔] Changelog record added
- [✔] Documentation updated (not only docstrings)
- [✔] Fixup commits are squashed away
- [✔] Unit tests added/updated
- [✔] Manual testing instructions provided
- [✔] Noted any: Concerns, dependencies, deadlines, tickets
