### PR TITLE
fix: Pip install this project in the python environment.

### DIFF
--- a/python-template/{{cookiecutter.placeholder_repo_name}}/.readthedocs.yaml
+++ b/python-template/{{cookiecutter.placeholder_repo_name}}/.readthedocs.yaml
@@ -19,3 +19,9 @@ build:
 python:
   install:
     - requirements: requirements/doc.txt
+
+    # This will pip install this repo into the python environment
+    # if you are using this in a repo that is not pip installable
+    # then you should remove the following two lines.
+    - method: pip
+      path: .


### PR DESCRIPTION
Since this example of the .readthedocs.yaml is in the python-template
cookiecutter, every repo that uses it will have a setup.py and will be
pip-installabale.  So we should have it install it in the docs build
environment by default to make auto documenting the code easier by
default.
