### PR TITLE
fix: remove pii_check from xblock cookiecutter

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,13 @@ Change Log
    This file loosely adheres to the structure of https://keepachangelog.com/,
    but in reStructuredText instead of Markdown.
 
+2023-12-13
+**********
+
+Changed
+=======
+- Remove pii_check from xblock cookiecutter
+
 2023-12-06
 **********
 

--- a/cookiecutter-xblock/{{cookiecutter.repo_name}}/.github/workflows/ci.yml
+++ b/cookiecutter-xblock/{{cookiecutter.repo_name}}/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         os: [ubuntu-20.04]
         python-version: ['3.8']
-        toxenv: [quality, docs, pii_check, django32, django40]
+        toxenv: [quality, docs, django32, django40]
 
     steps:
     - uses: actions/checkout@v3

--- a/cookiecutter-xblock/{{cookiecutter.repo_name}}/tox.ini
+++ b/cookiecutter-xblock/{{cookiecutter.repo_name}}/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py38-django{32,40}, quality, docs, pii_check
+envlist = py38-django{32,40}, quality, docs
 skipsdist = true
 
 [doc8]

--- a/cookiecutter-xblock/{{cookiecutter.repo_name}}/tox.ini
+++ b/cookiecutter-xblock/{{cookiecutter.repo_name}}/tox.ini
@@ -80,11 +80,3 @@ commands =
     pydocstyle {{ cookiecutter.package_name }} manage.py
     isort --check-only --diff test_utils {{ cookiecutter.package_name }} manage.py
     make selfcheck
-
-[testenv:pii_check]
-setenv =
-    DJANGO_SETTINGS_MODULE = translation_settings
-deps =
-    -r{toxinidir}/requirements/test.txt
-commands =
-    code_annotations django_find_annotations --config_file .pii_annotations.yml --lint --report --coverage


### PR DESCRIPTION
Removes pii check from xblock cookiecutter. The check causes any new xblock to automatically start failing ci checks. Since there are only 2 xblocks that have ever needed pii_annotations files (because they talk to the database), it makes more sense just to remove the check. Tested that this check is not run when creating an xblock from this updated cookiecutter.

This duplicates some work from https://github.com/openedx/edx-cookiecutters/pull/412, but extracts it out into its own PR for ease of management and control.

**Merge checklist:**
Check off if complete *or* not applicable:
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [ ] Fixup commits are squashed away
- [x] Unit tests added/updated
- [x] Manual testing instructions provided
- [x] Noted any: Concerns, dependencies, deadlines, tickets
