### PR TITLE
fix: remove unneeded build step from ci

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,13 @@ Change Log
    This file loosely adheres to the structure of https://keepachangelog.com/,
    but in reStructuredText instead of Markdown.
 
+2023-12-15
+**********
+
+Changed
+=======
+- Remove incorrect build step from xblock ci template
+
 2023-12-13
 **********
 

--- a/cookiecutter-xblock/{{cookiecutter.repo_name}}/.github/workflows/ci.yml
+++ b/cookiecutter-xblock/{{cookiecutter.repo_name}}/.github/workflows/ci.yml
@@ -31,13 +31,6 @@ jobs:
     - name: Install Dependencies
       run: pip install -r requirements/ci.txt
 
-    - name: Create Build
-      run: |
-        rm -rf /tmp/myxblock-xblock
-        XBLOCK=$(pwd) && cd /tmp/ && echo -e '\n\n\n\n\n' | cookiecutter $XBLOCK
-        cd /tmp/myxblock-xblock && make help && pip install -e .
-        cd /tmp/myxblock-xblock && make dev.build
-
     - name: Run Tests
       env:
         TOXENV: ${{ matrix.toxenv }}


### PR DESCRIPTION
Removes a step that tries to build using cookiecutter inside an already-created xblock repo. This was failing ci checks.

**Merge checklist:**
Check off if complete *or* not applicable:
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Fixup commits are squashed away
- [ ] Unit tests added/updated
- [ ] Manual testing instructions provided
- [ ] Noted any: Concerns, dependencies, deadlines, tickets
