### PR TITLE
fix: add unit test to xblock so there is a coverage file to upload

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,8 @@ Change Log
 Changed
 =======
 - Remove incorrect build step from xblock ci template
+- Fix docstrings
+- Add a unit test so coverage can run
 
 2023-12-13
 **********

--- a/cookiecutter-xblock/{{cookiecutter.repo_name}}/requirements/test.in
+++ b/cookiecutter-xblock/{{cookiecutter.repo_name}}/requirements/test.in
@@ -6,3 +6,4 @@
 pytest-cov                # pytest extension for code coverage statistics
 pytest-django             # pytest extension for better Django support
 code-annotations          # provides commands used by the pii_check make target.
+xblock-sdk                # provides workbench settings for testing

--- a/cookiecutter-xblock/{{cookiecutter.repo_name}}/tests/test_{{cookiecutter.package_name}}.py
+++ b/cookiecutter-xblock/{{cookiecutter.repo_name}}/tests/test_{{cookiecutter.package_name}}.py
@@ -5,6 +5,7 @@ Tests for {{cookiecutter.class_name}}
 from django.test import TestCase
 from xblock.fields import ScopeIds
 from xblock.test.toy_runtime import ToyRuntime
+
 from my_xblock import MyXBlock
 
 

--- a/cookiecutter-xblock/{{cookiecutter.repo_name}}/tests/test_{{cookiecutter.package_name}}.py
+++ b/cookiecutter-xblock/{{cookiecutter.repo_name}}/tests/test_{{cookiecutter.package_name}}.py
@@ -1,14 +1,16 @@
 """
-Tests for pipeline.py
+Tests for {{cookiecutter.class_name}}
 """
 
 from django.test import TestCase
-from my_xblock import MyXBlock
-from xblock.test.toy_runtime import ToyRuntime
 from xblock.fields import ScopeIds
+from xblock.test.toy_runtime import ToyRuntime
+from my_xblock import MyXBlock
 
 class Test{{cookiecutter.class_name}}(TestCase):
+    """Tests for {{cookiecutter.class_name}}"""
     def test_my_student_view(self):
+        """Test the basic view loads."""
         scope_ids = ScopeIds('1','2','3','4')
         block = MyXBlock(ToyRuntime(), scope_ids=scope_ids)
         frag = block.student_view()

--- a/cookiecutter-xblock/{{cookiecutter.repo_name}}/tests/test_{{cookiecutter.package_name}}.py
+++ b/cookiecutter-xblock/{{cookiecutter.repo_name}}/tests/test_{{cookiecutter.package_name}}.py
@@ -1,0 +1,17 @@
+"""
+Tests for pipeline.py
+"""
+
+from django.test import TestCase
+from my_xblock import MyXBlock
+from xblock.test.toy_runtime import ToyRuntime
+from xblock.fields import ScopeIds
+
+class Test{{cookiecutter.class_name}}(TestCase):
+    def test_my_student_view(self):
+        scope_ids = ScopeIds('1','2','3','4')
+        block = MyXBlock(ToyRuntime(), scope_ids=scope_ids)
+        frag = block.student_view()
+        as_dict = frag.to_dict()
+        content = as_dict['content']
+        self.assertIn('MyXBlock: count is now', content, 'XBlock did not render correct student view')

--- a/cookiecutter-xblock/{{cookiecutter.repo_name}}/tests/test_{{cookiecutter.package_name}}.py
+++ b/cookiecutter-xblock/{{cookiecutter.repo_name}}/tests/test_{{cookiecutter.package_name}}.py
@@ -7,11 +7,12 @@ from xblock.fields import ScopeIds
 from xblock.test.toy_runtime import ToyRuntime
 from my_xblock import MyXBlock
 
+
 class Test{{cookiecutter.class_name}}(TestCase):
     """Tests for {{cookiecutter.class_name}}"""
     def test_my_student_view(self):
         """Test the basic view loads."""
-        scope_ids = ScopeIds('1','2','3','4')
+        scope_ids = ScopeIds('1', '2', '3', '4')
         block = MyXBlock(ToyRuntime(), scope_ids=scope_ids)
         frag = block.student_view()
         as_dict = frag.to_dict()

--- a/cookiecutter-xblock/{{cookiecutter.repo_name}}/tox.ini
+++ b/cookiecutter-xblock/{{cookiecutter.repo_name}}/tox.ini
@@ -41,6 +41,7 @@ deps =
     django40: Django>=4.0,<4.1
     -r{toxinidir}/requirements/test.txt
 commands =
+    mkdir -p var
     pytest {posargs}
 
 [testenv:docs]

--- a/cookiecutter-xblock/{{cookiecutter.repo_name}}/tox.ini
+++ b/cookiecutter-xblock/{{cookiecutter.repo_name}}/tox.ini
@@ -31,7 +31,7 @@ ignore = D101,D200,D203,D212,D215,D404,D405,D406,D407,D408,D409,D410,D411,D412,D
 match-dir = (?!migrations)
 
 [pytest]
-DJANGO_SETTINGS_MODULE = translation_settings
+DJANGO_SETTINGS_MODULE = workbench.settings
 addopts = --cov {{ cookiecutter.package_name }} --cov-report term-missing --cov-report xml
 norecursedirs = .* docs requirements site-packages
 

--- a/cookiecutter-xblock/{{cookiecutter.repo_name}}/tox.ini
+++ b/cookiecutter-xblock/{{cookiecutter.repo_name}}/tox.ini
@@ -40,6 +40,8 @@ deps =
     django32: Django>=3.2,<4.0
     django40: Django>=4.0,<4.1
     -r{toxinidir}/requirements/test.txt
+allowlist_externals =
+    mkdir
 commands =
     mkdir -p var
     pytest {posargs}


### PR DESCRIPTION
Adds a very basic unit test to the cookiecutter-created xblock. This allows coverage to run and gets passed the `No coverage files located` error


**Merge checklist:**
Check off if complete *or* not applicable:
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [ ] Fixup commits are squashed away
- [x] Unit tests added/updated
- [ ] Manual testing instructions provided
- [ ] Noted any: Concerns, dependencies, deadlines, tickets
