### PR TITLE
build: Update codecov and use token

### DIFF
--- a/cookiecutter-django-app/{{cookiecutter.repo_name}}/.github/workflows/ci.yml
+++ b/cookiecutter-django-app/{{cookiecutter.repo_name}}/.github/workflows/ci.yml
@@ -38,7 +38,8 @@ jobs:
 
     - name: Run coverage
       if: matrix.python-version == '3.8' && matrix.toxenv == 'django32'
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v4
       with:
+        token: ${{ secrets.CODECOV_TOKEN }}
         flags: unittests
         fail_ci_if_error: true

--- a/cookiecutter-xblock/{{cookiecutter.repo_name}}/.github/workflows/ci.yml
+++ b/cookiecutter-xblock/{{cookiecutter.repo_name}}/.github/workflows/ci.yml
@@ -38,7 +38,8 @@ jobs:
 
     - name: Run coverage
       if: matrix.python-version == '3.8' && matrix.toxenv == 'django32'
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v4
       with:
+        token: ${{ secrets.CODECOV_TOKEN }}
         flags: unittests
         fail_ci_if_error: true

--- a/python-template/{{cookiecutter.placeholder_repo_name}}/.github/workflows/ci.yml
+++ b/python-template/{{cookiecutter.placeholder_repo_name}}/.github/workflows/ci.yml
@@ -38,7 +38,8 @@ jobs:
 
       - name: Run coverage
         if: matrix.python-version == '3.8' && matrix.toxenv == 'py38'
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           flags: unittests
           fail_ci_if_error: true


### PR DESCRIPTION
Update codecov to the latest version and start using the org-wide token for uploads.

See https://github.com/openedx/wg-frontend/issues/179
