### PR TITLE
build: Switch to ubuntu-latest for builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04]
+        os: [ubuntu-latest]
         python-version:
         - '3.12'
         toxenv: [py, quality]
@@ -50,7 +50,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04]
+        os: [ubuntu-latest]
         python-version:
         - '3.12'
     steps:

--- a/.github/workflows/upgrade-python-requirements.yml
+++ b/.github/workflows/upgrade-python-requirements.yml
@@ -14,8 +14,9 @@ jobs:
     with:
        branch: ${{ github.event.inputs.branch }}
        team_reviewers: "arbi-bom"
-       email_address: arbi-bom@edx.org  
+       email_address: arbi-bom@edx.org
        send_success_notification: false
+       python_version: "3.12"
     secrets:
        requirements_bot_github_token: ${{ secrets.REQUIREMENTS_BOT_GITHUB_TOKEN }}
        requirements_bot_github_email: ${{ secrets.REQUIREMENTS_BOT_GITHUB_EMAIL }}

--- a/cookiecutter-django-app/{{cookiecutter.repo_name}}/.github/workflows/ci.yml
+++ b/cookiecutter-django-app/{{cookiecutter.repo_name}}/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04]
+        os: [ubuntu-latest]
         python-version: ['3.8']
         toxenv: [quality, docs, pii_check, django32, django40]
 

--- a/cookiecutter-django-ida/{{cookiecutter.repo_name}}/.github/workflows/check-reserved-keywords.yml
+++ b/cookiecutter-django-ida/{{cookiecutter.repo_name}}/.github/workflows/check-reserved-keywords.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   check-reserved-keywords:
     name: Check Reserved Keywords
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
     - name: Checkout code

--- a/cookiecutter-xblock/{{cookiecutter.repo_name}}/.github/workflows/ci.yml
+++ b/cookiecutter-xblock/{{cookiecutter.repo_name}}/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04]
+        os: [ubuntu-latest]
         python-version: ['3.8']
         toxenv: [quality, docs, django32, django40]
 

--- a/python-template/{{cookiecutter.placeholder_repo_name}}/.github/workflows/ci.yml
+++ b/python-template/{{cookiecutter.placeholder_repo_name}}/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04]
+        os: [ubuntu-latest]
         python-version: ['3.8']
         toxenv: ["py38", "quality", "docs", "pii_check"]
 

--- a/python-template/{{cookiecutter.placeholder_repo_name}}/.github/workflows/pypi-publish.yml
+++ b/python-template/{{cookiecutter.placeholder_repo_name}}/.github/workflows/pypi-publish.yml
@@ -7,7 +7,7 @@ on:
 jobs:
 
   push:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout


### PR DESCRIPTION
This code does not have any dependencies that are specific to any specific
version of ubuntu.  So instead of testing on a specific version and then needing
to do work to keep the versions up-to-date, we switch to the ubuntu-latest
target which should be sufficient for testing purposes.

This work is being done as a part of https://github.com/openedx/platform-roadmap/issues/377

closes https://github.com/openedx/edx-cookiecutters/issues/478
