### PR TITLE
chore: fix python ci status badge

### DIFF
--- a/python-template/{{cookiecutter.placeholder_repo_name}}/README.rst
+++ b/python-template/{{cookiecutter.placeholder_repo_name}}/README.rst
@@ -119,8 +119,8 @@ Please do not report security issues in public. Please email security@openedx.or
     :target: https://pypi.python.org/pypi/{{ cookiecutter.repo_name }}/
     :alt: PyPI
 
-.. |ci-badge| image:: https://github.com/{{ cookiecutter.github_org }}/{{ cookiecutter.repo_name }}/workflows/Python%20CI/badge.svg?branch=main
-    :target: https://github.com/{{ cookiecutter.github_org }}/{{ cookiecutter.repo_name }}/actions
+.. |ci-badge| image:: https://github.com/{{ cookiecutter.github_org }}/{{ cookiecutter.repo_name }}/actions/workflows/ci.yml/badge.svg?branch=main
+    :target: https://github.com/{{ cookiecutter.github_org }}/{{ cookiecutter.repo_name }}/actions/workflows/ci.yml
     :alt: CI
 
 .. |codecov-badge| image:: https://codecov.io/github/{{ cookiecutter.github_org }}/{{ cookiecutter.repo_name }}/coverage.svg?branch=main


### PR DESCRIPTION
### Description
This PR fixes the Python CI status badge in the common `README.rst` for all repositories. This was tested with these repositories:
- https://github.com/openedx/openedx-events/pull/485
- https://github.com/openedx/openedx-filters/pull/277

### Screenshots

#### Before
![image](https://github.com/user-attachments/assets/726523b5-e7af-403d-8fa7-969631ca8ecf)

#### After
![image](https://github.com/user-attachments/assets/a4e50fce-9ed4-447a-88e2-c0ac1f6a3c25)

**Merge checklist:**
Check off if complete *or* not applicable:
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Fixup commits are squashed away
- [ ] Unit tests added/updated
- [ ] Manual testing instructions provided
- [ ] Noted any: Concerns, dependencies, deadlines, tickets
