### PR TITLE
style: This ignore is no longer necessary.

### DIFF
--- a/cookiecutter-django-app/{{cookiecutter.repo_name}}/manage.py
+++ b/cookiecutter-django-app/{{cookiecutter.repo_name}}/manage.py
@@ -18,7 +18,7 @@ if __name__ == '__main__':
         # issue is really that Django is missing to avoid masking other
         # exceptions on Python 2.
         try:
-            import django  # pylint: disable=unused-import, wrong-import-position
+            import django  # pylint: disable=unused-import
         except ImportError as import_error:
             raise ImportError(
                 "Couldn't import Django. Are you sure it's installed and "


### PR DESCRIPTION
Pylint fails on freshly created projects if this ignore is here with a:

```
manage.py:21:0: I0021: Useless suppression of 'wrong-import-position' (useless-suppression)
```
