### PR TITLE
feat: [django-ida] allow logging format to be overridden

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,11 @@ Change Log
    This file loosely adheres to the structure of https://keepachangelog.com/,
    but in reStructuredText instead of Markdown.
 
+2025-04-14
+**********
+
+- feat: [django-ida] allow logging format to be overridden
+
 2024-08-03
 **********
 

--- a/cookiecutter-django-ida/{{cookiecutter.repo_name}}/{{cookiecutter.project_name}}/settings/base.py
+++ b/cookiecutter-django-ida/{{cookiecutter.repo_name}}/{{cookiecutter.project_name}}/settings/base.py
@@ -239,5 +239,8 @@ LOGIN_REDIRECT_URL = '/admin/'
 PLATFORM_NAME = 'Your Platform Name Here'
 # END OPENEDX-SPECIFIC CONFIGURATION
 
+# Override the default logging format string (default defined within utils.py).
+LOGGING_FORMAT_STRING = os.environ.get("LOGGING_FORMAT_STRING", None)
+
 # Set up logging for development use (logging to stdout)
-LOGGING = get_logger_config(debug=DEBUG)
+LOGGING = get_logger_config(debug=DEBUG, format_string=LOGGING_FORMAT_STRING)

--- a/cookiecutter-django-ida/{{cookiecutter.repo_name}}/{{cookiecutter.project_name}}/settings/local.py
+++ b/cookiecutter-django-ida/{{cookiecutter.repo_name}}/{{cookiecutter.project_name}}/settings/local.py
@@ -64,7 +64,7 @@ JWT_AUTH.update({
 
 ENABLE_AUTO_AUTH = True
 
-LOGGING = get_logger_config(debug=DEBUG)
+LOGGING = get_logger_config(debug=DEBUG, format_string=LOGGING_FORMAT_STRING)
 
 #####################################################################
 # Lastly, see if the developer has any local overrides.

--- a/cookiecutter-django-ida/{{cookiecutter.repo_name}}/{{cookiecutter.project_name}}/settings/production.py
+++ b/cookiecutter-django-ida/{{cookiecutter.repo_name}}/{{cookiecutter.project_name}}/settings/production.py
@@ -12,8 +12,6 @@ TEMPLATE_DEBUG = DEBUG
 
 ALLOWED_HOSTS = ['*']
 
-LOGGING = get_logger_config()
-
 # Keep track of the names of settings that represent dicts. Instead of overriding the values in base.py,
 # the values read from disk should UPDATE the pre-configured dicts.
 DICT_UPDATE_KEYS = ('JWT_AUTH',)
@@ -43,6 +41,9 @@ if '{{cookiecutter.project_name|upper}}_CFG' in environ:
         # of Django settings.
         vars().update(FILE_STORAGE_BACKEND)
         vars().update(MEDIA_STORAGE_BACKEND)
+
+# Must be generated after loading config YAML because LOGGING_FORMAT_STRING might be overridden.
+LOGGING = get_logger_config(format_string=LOGGING_FORMAT_STRING)
 
 DB_OVERRIDES = {
     "PASSWORD": environ.get('DB_MIGRATION_PASS', DATABASES['default']['PASSWORD']),

--- a/cookiecutter-django-ida/{{cookiecutter.repo_name}}/{{cookiecutter.project_name}}/settings/utils.py
+++ b/cookiecutter-django-ida/{{cookiecutter.repo_name}}/{{cookiecutter.project_name}}/settings/utils.py
@@ -17,14 +17,22 @@ def get_env_setting(setting):
 
 
 def get_logger_config(
-    logging_env="no_env",
-    debug=False,
-    service_variant='{{cookiecutter.repo_name}}',
+    logging_env: str = "no_env",
+    debug: bool = False,
+    service_variant: str = 'enterprise-access',
+    format_string: str = None,
 ):
     """
-    Return the appropriate logging config dictionary.
+    Return the appropriate logging config dictionary, to be assigned to the LOGGING var in settings.
 
-    You should assign the result of this to the LOGGING var in your settings.
+    Arguments:
+        logging_env (str): Environment name.
+        debug (bool): Debug logging enabled.
+        service_variant (str): Name of the service.
+        format_string (str): Override format string for your logfiles.
+
+    Returns:
+        dict(string): Returns a dictionary of config values
     """
     hostname = platform.node().split(".")[0]
     syslog_format = (
@@ -39,13 +47,18 @@ def get_logger_config(
 
     handlers = ['console']
 
+    standard_format = format_string or (
+        '%(asctime)s %(levelname)s %(process)d [%(name)s] '
+        '[user %(userid)s] [ip %(remoteip)s] '
+        '%(filename)s:%(lineno)d - %(message)s'
+    )
+
     logger_config = {
         'version': 1,
         'disable_existing_loggers': False,
         'formatters': {
             'standard': {
-                'format': '%(asctime)s %(levelname)s %(process)d '
-                          '[%(name)s] [user %(userid)s] [ip %(remoteip)s] %(filename)s:%(lineno)d - %(message)s',
+                'format': standard_format,
             },
             'syslog_format': {'format': syslog_format},
             'raw': {'format': '%(message)s'},


### PR DESCRIPTION
As part of ENT-10092 to correlate logs with DataDog traces, we need the ability to add trace/span IDs to the log lines. However, this being an open source project, we cannot assume a particular format and observability tool. Hence the need to allow operators to completely override the log format.

ENT-10092


**Merge checklist:**
Check off if complete *or* not applicable:
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Fixup commits are squashed away
- [x] Unit tests added/updated
- [x] Manual testing instructions provided
- [x] Noted any: Concerns, dependencies, deadlines, tickets
