### PR TITLE
Add Django52 Support

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,11 @@ Change Log
    This file loosely adheres to the structure of https://keepachangelog.com/,
    but in reStructuredText instead of Markdown.
 
+2025-04-18
+**********
+
+- Added support for Django 5.2
+
 2025-04-14
 **********
 

--- a/cookiecutter-django-app/{{cookiecutter.repo_name}}/.github/workflows/ci.yml
+++ b/cookiecutter-django-app/{{cookiecutter.repo_name}}/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         python-version: ["3.12"]
-        toxenv: [quality, docs, pii_check, django42]
+        toxenv: [quality, docs, pii_check, django42, django52]
     steps:
       - uses: actions/checkout@v4
       - name: setup python

--- a/cookiecutter-django-app/{{cookiecutter.repo_name}}/tox.ini
+++ b/cookiecutter-django-app/{{cookiecutter.repo_name}}/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py312-django{42}
+envlist = py312-django{42,52}
 
 [doc8]
 ; D001 = Line too long
@@ -37,6 +37,7 @@ norecursedirs = .* docs requirements site-packages
 [testenv]
 deps =
     django42: Django>=4.0,<5.0
+    django52: Django>=5.0,<5.3
     -r{toxinidir}/requirements/test.txt
 commands =
     python manage.py check

--- a/cookiecutter-django-ida/{{cookiecutter.repo_name}}/tox.ini
+++ b/cookiecutter-django-ida/{{cookiecutter.repo_name}}/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py312-django{42}, quality, docs, pii_check
+envlist = py312-django{42,52}, quality, docs, pii_check
 skipsdist = true
 
 [doc8]
@@ -44,6 +44,7 @@ filterwarnings =
 [testenv]
 deps =
     django42: Django>=4.0,<5.0
+    django52: Django>=5.0,<5.3
     -r{toxinidir}/requirements/test.txt
 commands =
     pytest {posargs}

--- a/cookiecutter-xblock/{{cookiecutter.repo_name}}/.github/workflows/ci.yml
+++ b/cookiecutter-xblock/{{cookiecutter.repo_name}}/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         python-version: ["3.12"]
-        toxenv: [quality, docs, django42]
+        toxenv: [quality, docs, django42, django52]
     steps:
       - uses: actions/checkout@v4
       - name: setup python

--- a/cookiecutter-xblock/{{cookiecutter.repo_name}}/tox.ini
+++ b/cookiecutter-xblock/{{cookiecutter.repo_name}}/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py312-django{42}, quality, docs
+envlist = py312-django{42,52}, quality, docs
 skipsdist = true
 
 [doc8]
@@ -38,6 +38,7 @@ norecursedirs = .* docs requirements site-packages
 [testenv]
 deps =
     django42: Django>=4.0,<5.0
+    django52: Django>=5.0,<5.3
     -r{toxinidir}/requirements/test.txt
 allowlist_externals =
     mkdir

--- a/cookiecutter-xblock/{{cookiecutter.repo_name}}/translation_settings.py
+++ b/cookiecutter-xblock/{{cookiecutter.repo_name}}/translation_settings.py
@@ -28,8 +28,6 @@ TIME_ZONE = 'UTC'
 
 USE_I18N = True
 
-USE_L10N = True
-
 USE_TZ = True
 
 

--- a/python-template/{{cookiecutter.placeholder_repo_name}}/setup.py
+++ b/python-template/{{cookiecutter.placeholder_repo_name}}/setup.py
@@ -173,6 +173,7 @@ setup(
         {%- if cookiecutter.requires_django == "yes" %}
         'Framework :: Django',
         'Framework :: Django :: 4.2',
+        'Framework :: Django :: 5.2',
         {%- endif %}
         'Intended Audience :: Developers',
         {%- if cookiecutter.open_source_license == "AGPL 3.0" %}


### PR DESCRIPTION
- Resolved https://github.com/openedx/edx-cookiecutters/issues/524


### Add Django 5.2 Support

This PR updates the codebase to be compatible with Django 5.2 while maintaining compatibility with Django 4.2.

Changes Made:
- Update `ci` and `tox` files for cookie-cutter packages
- Ran `django-upgrade` to apply necessary syntax updates for Django 5.2.
- Run tests using `tox` command and resolved the warning 
- Ensured all modifications remain backward-compatible with Django 4.2.

#### django-upgrade usage:

I ran command `git ls-files -z -- '*.py' | xargs -0r django-upgrade --target-version 5.2`